### PR TITLE
Improve abstract type resolver

### DIFF
--- a/src/mirage/resolver/abstract.ts
+++ b/src/mirage/resolver/abstract.ts
@@ -10,7 +10,7 @@ export const mirageAbstractTypeResolver: GraphQLTypeResolver<any, any> = functio
   _info,
   abstractType: GraphQLAbstractType,
 ) {
-  const useFindInCommon = '__testUseFindInCommon' in context ? context.__testUseFindInCommon : true;
+  const useFindInCommon = '__useFindInCommon' in context ? context.__useFindInCommon : true;
 
   const { graphqlSchema } = extractDependencies<{
     graphqlSchema: GraphQLSchema;

--- a/src/mirage/resolver/abstract.ts
+++ b/src/mirage/resolver/abstract.ts
@@ -60,11 +60,14 @@ export const mirageAbstractTypeResolver: GraphQLTypeResolver<any, any> = functio
     if (modelName) {
       mirageModelMessage =
         `Received model "${modelName}" which did not match one of the possible types above. ` +
-        `If "${modelName}" represents of the possible types, fix the model name ` +
-        `or use a MirageGraphQLMapper instance with a type mapping. ` +
+        `If "${modelName}" represents one of the possible types, fix the model name ` +
+        `or use a MirageGraphQLMapper instance with a type mapping ["TypeName", "${modelName}"]. ` +
+        `\n\n` +
         `If "${modelName}" is the abstract type "${abstractType.name}", consider ` +
-        `only creating models for discrete types and using { polymorphic: true } ` +
-        `for the relationships that represent "${abstractType.name}"`;
+        `only creating models for discrete types and using { polymorphic: true } along with any ` +
+        `corresponding { inverse: true } relationships that point to the polymorphic field ` +
+        `that represent "${abstractType.name}. See the the Mirage JS section of the docs at ` +
+        `www.graphql-mocks.com for examples.`;
     }
 
     const lastResortMessage =

--- a/src/mirage/resolver/utils.ts
+++ b/src/mirage/resolver/utils.ts
@@ -11,7 +11,7 @@ function toPascalCase(string: string): string {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function findMostInCommon(parent: any, eligibleTypes: GraphQLObjectType[]): string | undefined {
+export function findTypeWithFieldsMostInCommon(parent: any, eligibleTypes: GraphQLObjectType[]): string | undefined {
   let matchedTypes: GraphQLObjectType[] = [];
   let matchedFieldCount = 0;
 
@@ -33,7 +33,7 @@ export function findMostInCommon(parent: any, eligibleTypes: GraphQLObjectType[]
   if (matchedTypes.length > 1) {
     const matchingTypeNames = matchedTypes.map((type) => type.name).join(', ');
     const matchedFields = parentFields.map((field) => `"${field}"`).join(', ');
-    const errorMessage = `Multiple types matched (${matchingTypeNames}) the fields: ${matchedFields}.`;
+    const errorMessage = `Multiple types matched (${matchingTypeNames}) against the fields from the object passed in: ${matchedFields}.`;
     throw new Error(errorMessage);
   }
 

--- a/test/unit/mirage/resolvers/abstract.test.ts
+++ b/test/unit/mirage/resolvers/abstract.test.ts
@@ -69,7 +69,7 @@ describe('mirage/resolvers/abstract', function () {
 
     it('resolves an union to a type by model name', async function () {
       const context = {
-        __testUseFindInCommon: false,
+        __useFindInCommon: false,
         pack: generatePackOptions({ dependencies: { graphqlSchema: schema } }),
       };
       const resolvedType = mirageAbstractTypeResolver(dogModel, context, resolverInfo, animalUnionType);
@@ -79,7 +79,7 @@ describe('mirage/resolvers/abstract', function () {
     it('resolves an union to a type by mapper', async function () {
       const mirageMapper = new MirageGraphQLMapper().addTypeMapping('Feline', 'Cat');
       const context = {
-        __testUseFindInCommon: false,
+        __useFindInCommon: false,
         pack: generatePackOptions({ dependencies: { mirageMapper, graphqlSchema: schema } }),
       };
       const resolvedType = mirageAbstractTypeResolver(catModel, context, resolverInfo, animalUnionType);
@@ -167,7 +167,7 @@ describe('mirage/resolvers/abstract', function () {
 
     it('resolves an interface to a type by model name', async function () {
       const context = {
-        __testUseFindInCommon: false,
+        __useFindInCommon: false,
         pack: generatePackOptions({ dependencies: { graphqlSchema: schema } }),
       };
 
@@ -179,7 +179,7 @@ describe('mirage/resolvers/abstract', function () {
       const mirageMapper = new MirageGraphQLMapper().addTypeMapping('Feline', 'Cat');
 
       const context = {
-        __testUseFindInCommon: false,
+        __useFindInCommon: false,
         pack: generatePackOptions({ dependencies: { mirageMapper, graphqlSchema: schema } }),
       };
 
@@ -189,7 +189,7 @@ describe('mirage/resolvers/abstract', function () {
 
     it('resolves an interface to a type by most matching fields', async function () {
       const context = {
-        __testUseFindInCommon: true,
+        __useFindInCommon: true,
         pack: generatePackOptions({ dependencies: { graphqlSchema: schema } }),
       };
 


### PR DESCRIPTION
* Improves on the outline and different methods of the Mirage JS Abstract Type Resolver
* Adds __typename checks
* Simplifies tests into specific test cases
* A few tweaks to the error messages