### PR TITLE
Remove the single enum in use

### DIFF
--- a/packages/graphql-mocks/src/highlight/utils/build-reference-map.ts
+++ b/packages/graphql-mocks/src/highlight/utils/build-reference-map.ts
@@ -29,13 +29,13 @@ export function buildReferenceMap(schema: GraphQLSchema, references: Reference[]
     })
     .forEach(([typeName, field]) => {
       if (field) {
-        map[typeName] = map[typeName] || {};
         const type = getTypeForReference(schema, typeName);
-        if (type) {
-          map[typeName].type = type;
-        }
+        if (!type) return;
 
-        map[typeName].fields = map[typeName].fields || {};
+        map[typeName] = map[typeName] ?? { type };
+
+        if (!field) return;
+        map[typeName].fields = map[typeName].fields ?? {};
 
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         map[typeName].fields![field.name] = field;

--- a/packages/graphql-mocks/src/resolver/apply-wrappers.ts
+++ b/packages/graphql-mocks/src/resolver/apply-wrappers.ts
@@ -1,6 +1,6 @@
 import { FieldResolver, TypeResolver } from '../types';
 import { isObjectType, isAbstractType } from 'graphql';
-import { Wrapper, NamedWrapper, BaseWrapperOptions } from './types';
+import { Wrapper, NamedWrapper, BaseWrapperOptions, GenericWrapperFunction } from './types';
 import { WrapperFor } from './constants';
 
 function isNamedWrapper(wrapper: Wrapper): wrapper is NamedWrapper {
@@ -44,7 +44,7 @@ export async function applyWrappers<K extends TypeResolver | FieldResolver>(
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const wrappedResolver = await wrapper(resolver as any, wrapperOptions as any);
+  const wrappedResolver = await (wrapper as GenericWrapperFunction)(resolver as any, wrapperOptions as any);
 
   if (typeof wrappedResolver !== 'function') {
     throw new Error(

--- a/packages/graphql-mocks/src/resolver/constants.ts
+++ b/packages/graphql-mocks/src/resolver/constants.ts
@@ -1,5 +1,5 @@
-export enum WrapperFor {
-  TYPE = 'TYPE',
-  FIELD = 'FIELD',
-  ANY = 'ANY',
-}
+export const WrapperFor = {
+  TYPE: 'TYPE',
+  FIELD: 'FIELD',
+  ANY: 'ANY',
+} as const;

--- a/packages/graphql-mocks/src/resolver/create-wrapper.ts
+++ b/packages/graphql-mocks/src/resolver/create-wrapper.ts
@@ -36,11 +36,11 @@ function hasTypeResolverPackage(
 class InternalNamedWrapper implements NamedWrapper {
   name: string;
   wrapper: FieldWrapperFunction | TypeWrapperFunction | GenericWrapperFunction;
-  wrapperFor: WrapperFor;
+  wrapperFor: typeof WrapperFor[keyof typeof WrapperFor];
 
   constructor(
     name: string,
-    wrapperFor: WrapperFor,
+    wrapperFor: typeof WrapperFor[keyof typeof WrapperFor],
     wrapperFn: FieldWrapperFunction | TypeWrapperFunction | GenericWrapperFunction,
   ) {
     if (typeof name !== 'string') {
@@ -102,7 +102,7 @@ type WrapperFn = {
   [WrapperFor.ANY]: GenericWrapperFunction;
 };
 
-export function createWrapper<K extends WrapperFor>(
+export function createWrapper<K extends typeof WrapperFor[keyof typeof WrapperFor]>(
   name: string,
   wrapperFor: K,
   wrapperFn: WrapperFn[K],

--- a/packages/graphql-mocks/src/resolver/types.ts
+++ b/packages/graphql-mocks/src/resolver/types.ts
@@ -39,7 +39,7 @@ export type GenericWrapperFunction = (
 export interface NamedWrapper {
   name: string;
   wrap: GenericWrapperFunction;
-  wrapperFor: WrapperFor;
+  wrapperFor: typeof WrapperFor[keyof typeof WrapperFor];
 }
 
 export type Wrapper = NamedWrapper | GenericWrapperFunction | FieldWrapperFunction | TypeWrapperFunction;

--- a/packages/graphql-mocks/test/unit/resolver/create-wrapper.test.ts
+++ b/packages/graphql-mocks/test/unit/resolver/create-wrapper.test.ts
@@ -12,7 +12,7 @@ import {
 } from '../../../src/resolver/types';
 import { GraphQLObjectType, GraphQLAbstractType, GraphQLResolveInfo, isInterfaceType } from 'graphql';
 
-function generateTypeWrapperOptions(wrapperFor: WrapperFor): BaseWrapperOptions {
+function generateTypeWrapperOptions(wrapperFor: typeof WrapperFor[keyof typeof WrapperFor]): BaseWrapperOptions {
   let type: GraphQLObjectType | GraphQLAbstractType | undefined = undefined;
   let field: ObjectField | undefined;
 


### PR DESCRIPTION
> Enums are one of the few features TypeScript has which is not a type-level extension of JavaScript.

To improve the experience provided by typings the one enum in use is being converted to a `const` object. This allows people to easily use the string representation instead of having to reference the enum.

```js
import WrapperFor from '...'
createWrapper('namedWrapper', WrapperFor.TYPE, wrapperFn);
```

to *also* allowing just using the string const directly:
```js
import WrapperFor from '...'
createWrapper('namedWrapper', "TYPE", wrapperFn);
```
The choices would still autocomplete.

This is more flexible and creates an output closer to pure javascript without the complexities and exceptions around enums in typescript, but is technically less accurate.