### PR TITLE
Improve wrapper typings

### DIFF
--- a/packages/graphql-mocks/src/resolver/apply-wrappers.ts
+++ b/packages/graphql-mocks/src/resolver/apply-wrappers.ts
@@ -1,9 +1,9 @@
 import { FieldResolver, TypeResolver } from '../types';
 import { isObjectType, isAbstractType } from 'graphql';
-import { Wrapper, NamedWrapper, BaseWrapperOptions, GenericWrapperFunction } from './types';
+import { Wrapper, NamedWrapper, BaseWrapperOptions, GenericWrapperFunction, WrapperForOptions } from './types';
 import { WrapperFor } from './constants';
 
-function isNamedWrapper(wrapper: Wrapper): wrapper is NamedWrapper {
+function isNamedWrapper<T extends WrapperForOptions>(wrapper: Wrapper): wrapper is NamedWrapper<T> {
   return wrapper && 'name' in wrapper && 'wrap' in wrapper;
 }
 

--- a/packages/graphql-mocks/src/resolver/types.ts
+++ b/packages/graphql-mocks/src/resolver/types.ts
@@ -36,10 +36,22 @@ export type GenericWrapperFunction = (
   options: BaseWrapperOptions,
 ) => FieldResolver | TypeResolver | Promise<FieldResolver | TypeResolver>;
 
-export interface NamedWrapper {
+export type WrapperForOptions = typeof WrapperFor[keyof typeof WrapperFor];
+
+export type WrapperFnMapping = {
+  [WrapperFor.FIELD]: FieldWrapperFunction;
+  [WrapperFor.TYPE]: TypeWrapperFunction;
+  [WrapperFor.ANY]: GenericWrapperFunction;
+};
+
+export interface NamedWrapper<T extends WrapperForOptions> {
   name: string;
-  wrap: GenericWrapperFunction;
-  wrapperFor: typeof WrapperFor[keyof typeof WrapperFor];
+  wrap: WrapperFnMapping[T];
+  wrapperFor: T;
 }
 
-export type Wrapper = NamedWrapper | GenericWrapperFunction | FieldWrapperFunction | TypeWrapperFunction;
+export type Wrapper =
+  | NamedWrapper<WrapperForOptions>
+  | GenericWrapperFunction
+  | FieldWrapperFunction
+  | TypeWrapperFunction;


### PR DESCRIPTION
This will provide better type inference around using `applyWrappers` and `createWrapper` by expanding on the `NamedWrapper` type to be more specific by providing a type argument.