### PR TITLE
Clean up circular dependencies

### DIFF
--- a/packages/docs/.babelrc
+++ b/packages/docs/.babelrc
@@ -1,4 +1,0 @@
-{
-  "presets": ["@babel/preset-env"],
-  "plugins": ["codegen"]
-}

--- a/packages/docs/.mocharc.yaml
+++ b/packages/docs/.mocharc.yaml
@@ -1,3 +1,3 @@
 require:
-  - '@babel/register'
+  - './scripts/register-babel-for-tests'
   - 'regenerator-runtime/runtime'

--- a/packages/docs/babel.config.js
+++ b/packages/docs/babel.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  presets: ['@babel/preset-env', require.resolve('@docusaurus/core/lib/babel/preset')],
+  plugins: ['codegen', '@babel/plugin-transform-modules-commonjs'],
+};

--- a/packages/docs/scripts/register-babel-for-tests.js
+++ b/packages/docs/scripts/register-babel-for-tests.js
@@ -1,0 +1,5 @@
+require('@babel/register')({
+  presets: ['@babel/preset-env'],
+  plugins: ['codegen'],
+  configFile: false,
+});

--- a/packages/graphql-mocks/src/graphql/utils/create-schema.ts
+++ b/packages/graphql-mocks/src/graphql/utils/create-schema.ts
@@ -1,5 +1,5 @@
 import { GraphQLSchema, DocumentNode, isSchema, buildASTSchema, buildSchema } from 'graphql';
-import { copySchema } from '../utils';
+import { copySchema } from '../utils/copy-schema';
 
 export function createSchema(schema: GraphQLSchema | DocumentNode | string): GraphQLSchema {
   if (isSchema(schema)) return copySchema(schema);

--- a/packages/graphql-mocks/src/highlight/highlighter/reference.ts
+++ b/packages/graphql-mocks/src/highlight/highlighter/reference.ts
@@ -1,5 +1,5 @@
 import { Highlighter, Reference, HighlighterFactory } from '../types';
-import { isReference } from '../utils';
+import { isReference } from '../utils/is-reference';
 
 export const reference: HighlighterFactory<Reference[]> = function reference(...references: Reference[]): Highlighter {
   return {

--- a/packages/graphql-mocks/src/highlight/utils/walk.ts
+++ b/packages/graphql-mocks/src/highlight/utils/walk.ts
@@ -1,6 +1,7 @@
 import { GraphQLSchema } from 'graphql';
 import { Reference, WalkCallback } from '../types';
-import { getTypeForReference, getFieldForReference } from '.';
+import { getTypeForReference } from './get-type-for-reference';
+import { getFieldForReference } from './get-field-for-reference';
 
 export async function walk(
   graphqlSchema: GraphQLSchema,

--- a/packages/graphql-mocks/src/relay/paginate-nodes.ts
+++ b/packages/graphql-mocks/src/relay/paginate-nodes.ts
@@ -1,4 +1,4 @@
-import { applyCursorsToEdges } from '.';
+import { applyCursorsToEdges } from './apply-cursor-to-edges';
 import { createEdge } from './create-edge';
 import { CursorForNode, RelayPaginationResult } from './types';
 

--- a/packages/graphql-mocks/src/relay/wrapper.ts
+++ b/packages/graphql-mocks/src/relay/wrapper.ts
@@ -2,7 +2,7 @@ import { createWrapper } from '../resolver';
 import { coerceToList } from '../resolver/utils';
 import { isRelayConnectionField } from './is-relay-connection-field';
 import { CursorForNode } from './types';
-import { paginateNodes } from '.';
+import { paginateNodes } from './paginate-nodes';
 import { NamedWrapper } from '../resolver/types';
 
 export const relayWrapper = ({

--- a/packages/graphql-mocks/src/resolver-map/embed.ts
+++ b/packages/graphql-mocks/src/resolver-map/embed.ts
@@ -6,7 +6,8 @@ import { ReplaceableResolverOption, HighlightableOption, WrappableOption } from 
 import { highlightAllCallback } from './utils/highlight-all-callback';
 import { embedPackOptionsWrapper } from '../pack/utils';
 import { getResolver } from './get-resolver';
-import { coerceHighlight, isTypeReference, isFieldReference, getInstanceForReference } from '../highlight/utils';
+import { isTypeReference, isFieldReference, getInstanceForReference } from '../highlight/utils';
+import { coerceHighlight } from '../highlight/utils/coerce-highlight';
 import { interfaces, combine, resolvesTo, union } from '../highlight';
 
 export type EmbedOptions = {


### PR DESCRIPTION
Rollup had warnings related to a few circular dependencies. It didn't appear that these caused any issues but it was easy enough to clean up. The `babel.rc` file was converted to a `babel.config.js` as referenced in the Docusaurus docs, this along with `@babel/plugin-transform-modules-commonjs`, might fix bundling issues with the homepage graphiql example. The `.babelrc` configuration values that was there before was still needed for tests and was moved to the arguments directly for `babel-register`.
