### PR TITLE
Add new-package starter template

### DIFF
--- a/packages/graphql-mocks/package.json
+++ b/packages/graphql-mocks/package.json
@@ -19,7 +19,8 @@
     "watch": "rollup --watch -c rollup-watch.config.js"
   },
   "publishConfig": {
-    "directory": "dist"
+    "directory": "dist",
+    "access": "public"
   },
   "engines": {
     "node": ">= 12.0.0"

--- a/packages/mirage/package.json
+++ b/packages/mirage/package.json
@@ -19,7 +19,8 @@
     "watch": "rollup --watch -c rollup-watch.config.js"
   },
   "publishConfig": {
-    "directory": "dist"
+    "directory": "dist",
+    "access": "public"
   },
   "engines": {
     "node": ">= 12.0.0"

--- a/packages/network-nock/package.json
+++ b/packages/network-nock/package.json
@@ -19,7 +19,8 @@
     "watch": "rollup --watch -c rollup-watch.config.js"
   },
   "publishConfig": {
-    "directory": "dist"
+    "directory": "dist",
+    "access": "public"
   },
   "engines": {
     "node": ">= 12.0.0"

--- a/packages/paper/package.json
+++ b/packages/paper/package.json
@@ -19,7 +19,8 @@
     "watch": "rollup --watch -c rollup-watch.config.js"
   },
   "publishConfig": {
-    "directory": "dist"
+    "directory": "dist",
+    "access": "public"
   },
   "engines": {
     "node": ">= 12.0.0"

--- a/packages/sinon/package.json
+++ b/packages/sinon/package.json
@@ -19,7 +19,8 @@
     "watch": "rollup --watch -c rollup-watch.config.js"
   },
   "publishConfig": {
-    "directory": "dist"
+    "directory": "dist",
+    "access": "public"
   },
   "engines": {
     "node": ">= 12.0.0"

--- a/templates/new-package/package.json
+++ b/templates/new-package/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@graphql-mocks/**REPLACE ME**",
+  "version": "0.0.0",
+  "author": "Chad Carbert",
+  "description": "**REPLACE ME**",
+  "type": "commonjs",
+  "main": "dist/index.js",
+  "module": "dist/es/index.js",
+  "unpkg": "dist/bundles/**REPLACE ME**.umd.js",
+  "types": "dist/index.d.ts",
+  "license": "MIT",
+  "scripts": {
+    "lint": "eslint \"./src/**/*.ts\" \"./test/**/*.ts\"",
+    "pretest": "tsc --noEmit && yarn lint",
+    "test": "TS_NODE_PROJECT=\"./test/tsconfig.json\" mocha -r ts-node/register \"./test/**/*.test.ts\"",
+    "clean": "rimraf ./dist",
+    "copy-pjson": "node scripts/copy-scrubbed-pjson",
+    "build": "yarn clean && rollup -c rollup.config.js && yarn copy-pjson",
+    "watch": "rollup --watch -c rollup-watch.config.js"
+  },
+  "publishConfig": {
+    "directory": "dist",
+    "access": "public"
+  },
+  "engines": {
+    "node": ">= 12.0.0"
+  },
+  "devDependencies": {
+  },
+  "peerDependencies": {
+  }
+}

--- a/templates/new-package/rollup-watch.config.js
+++ b/templates/new-package/rollup-watch.config.js
@@ -1,0 +1,3 @@
+import { buildConfig } from '../../build-utils/rollup';
+import pkg from './package.json';
+export default buildConfig(pkg, ['cjs', 'es'], { external: [/^graphql-mocks\/.*/] });

--- a/templates/new-package/rollup.config.js
+++ b/templates/new-package/rollup.config.js
@@ -1,0 +1,7 @@
+import { buildConfig } from '../../build-utils/rollup';
+import pkg from './package.json';
+
+export default buildConfig(pkg, ['cjs', 'es', 'umd'], {
+  external: [/^graphql-mocks\/.*/],
+  bundleGlobalName: '**REPLACE ME**',
+});

--- a/templates/new-package/scripts/copy-scrubbed-pjson.js
+++ b/templates/new-package/scripts/copy-scrubbed-pjson.js
@@ -1,0 +1,1 @@
+../../../scripts/copy-scrubbed-pjson.js

--- a/templates/new-package/test/tsconfig.json
+++ b/templates/new-package/test/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2017"
+  }
+}

--- a/templates/new-package/test/unit/index.test.ts
+++ b/templates/new-package/test/unit/index.test.ts
@@ -1,0 +1,7 @@
+import { expect } from 'chai';
+
+describe('index', function () {
+  it('works', async function () {
+    expect(true).to.be.true;
+  });
+});

--- a/templates/new-package/tsconfig.json
+++ b/templates/new-package/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": [
+    "src",
+  ],
+  "exclude": ["./test"],
+  "compilerOptions": {
+    "rootDir": "./src"
+  }
+}


### PR DESCRIPTION
When a package hasn't been published before **and** it's scoped `@graphql-mocks/*` lerna will fail to publish. This pull request adds `"access": "public"` to the `publishConfig` for existing packages and includes it in the new package template. The new package will help with the boilerplate of starting new packages 🕺