### PR TITLE
Allow docs to be package.json to be versioned

### DIFF
--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -26,7 +26,7 @@
     "@graphql-mocks/mirage": "^0.3.0",
     "classnames": "^2.2.6",
     "graphiql": "0.17.5",
-    "graphql-mocks": "^0.7.0",
+    "graphql-mocks": "^0.8.0",
     "graphql-paper": "^0.1.0",
     "graphql-tools": "^6.0.11",
     "react": "^16.8.4",

--- a/scripts/create-release.js
+++ b/scripts/create-release.js
@@ -21,7 +21,7 @@ try {
   execSync(`git checkout -b release-${commit}`);
   execSync(`git push -u origin release-${commit}`);
 
-  execSync('yarn lerna version --no-private', {
+  execSync('yarn lerna version', {
     cwd: process.cwd(),
     env: process.env,
     stdio: 'inherit',


### PR DESCRIPTION
Although the docs aren't published as a package they should be versioned by lerna so that its dependencies that it shares, namely the core `graphql-mocks` package, gets bumped automatically and tested with the documentation tests in CI.

```markdown changelog(graphql-mocks)
Testing changelog entry for package graphql-mocks
```

```markdown changelog(@graphql-mocks/faker)
Testing another changelog entry
```