### PR TITLE
Check for uncommitted yarn.lock before creating release pr

### DIFF
--- a/scripts/create-release.js
+++ b/scripts/create-release.js
@@ -6,13 +6,30 @@ const { exit } = require('process');
 
 const currentBranch = execSync('git branch --show-current').toString().trim();
 if (currentBranch !== 'main') {
-  console.error('Ensure create-release is ran from the main branch');
+  console.error('');
+  console.error('***************************************************');
+  console.error('');
+  console.error(' Ensure create-release is ran from the main branch ');
+  console.error('');
+  console.error('***************************************************');
+  console.error('');
   exit(-1);
 }
 
+// run yarn, if there are changes to yarn.lock then
+// the clean working directory check will fail
+console.log('Running yarn, to ensure no uncommitted changes to yarn.lock');
+execSync('yarn', { stdio: 'ignore' });
+
 const cleanWorkingDirectory = execSync('git status --porcelain').toString().trim() === '';
 if (!cleanWorkingDirectory) {
-  console.error('Ensure clean working directory before creating release pr');
+  console.error('');
+  console.error('******************************************************************');
+  console.error('');
+  console.error(' Error: Ensure clean working directory before creating release pr ');
+  console.error('');
+  console.error('******************************************************************');
+  console.error('');
   exit(-1);
 }
 


### PR DESCRIPTION
Small improvement to the avoid hangups on the publish step to ensure that the release pr isn't created without any missing yarn.lock updates.