### PR TITLE
Improve create-release script 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# CHANGELOG
+
+## graphql-mocks
+
+## graphql-paper

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@typescript-eslint/eslint-plugin": "^4.1.0",
     "@typescript-eslint/parser": "^4.1.0",
     "chai": "^4.2.0",
+    "chalk": "^4.1.2",
     "eslint": "^7.8.1",
     "eslint-config-prettier": "^6.10.0",
     "eslint-plugin-mocha": "^8.0.0",
@@ -49,6 +50,7 @@
     "prettier": "^2.1.1",
     "rimraf": "^3.0.2",
     "rollup": "^2.56.0",
+    "semver": "^7.3.5",
     "ts-node": "^9.0.0",
     "typescript": "^4.1.0"
   }

--- a/scripts/create-release.js
+++ b/scripts/create-release.js
@@ -3,47 +3,395 @@
 
 const { execSync } = require('child_process');
 const { exit } = require('process');
+const semver = require('semver');
+const chalk = require('chalk');
+const { writeFileSync, readFileSync } = require('fs');
+const path = require('path');
 
-const currentBranch = execSync('git branch --show-current').toString().trim();
-if (currentBranch !== 'main') {
-  console.error('');
-  console.error('***************************************************');
-  console.error('');
-  console.error(' Ensure create-release is ran from the main branch ');
-  console.error('');
-  console.error('***************************************************');
-  console.error('');
-  exit(-1);
+function yarnAndLink() {
+  console.log(chalk.blue(`running \`yarn\` and \`yarn link-packages\``));
+  execSync(`yarn`);
+  execSync(`yarn link-packages`);
+  console.log(chalk.green(`✅ finished running \`yarn\` and \`yarn link-packages\``));
 }
 
-// run yarn, if there are changes to yarn.lock then
-// the clean working directory check will fail
-console.log('Running yarn, to ensure no uncommitted changes to yarn.lock');
-execSync('yarn', { stdio: 'ignore' });
-
-const cleanWorkingDirectory = execSync('git status --porcelain').toString().trim() === '';
-if (!cleanWorkingDirectory) {
-  console.error('');
-  console.error('******************************************************************');
-  console.error('');
-  console.error(' Error: Ensure clean working directory before creating release pr ');
-  console.error('');
-  console.error('******************************************************************');
-  console.error('');
-  exit(-1);
+function getLernaPackages({ changed } = { changed: false }) {
+  if (changed) {
+    return JSON.parse(execSync('yarn --silent run lerna changed --json').toString());
+  } else {
+    return JSON.parse(execSync('yarn --silent run lerna ls --json').toString());
+  }
 }
 
-try {
+function getPublishedVersions(package) {
+  try {
+    return JSON.parse(execSync(`yarn info --json ${package}`).toString()).data.versions;
+  } catch {
+    return [];
+  }
+}
+
+let indentLevel = 0;
+function step(message) {
+  return {
+    start: () => (indentLevel++, console.log(chalk.blue(`${' '.repeat(2 * indentLevel)} ➡️  [START] ${message}`))),
+    stop: () => (indentLevel--, console.log(chalk.blue(`${' '.repeat(2 * indentLevel)} ⬅️  [STOP] ${message}`))),
+    error: () => (indentLevel--, console.log(chalk.red(`${' '.repeat(2 * indentLevel)} ❌ [ERROR] ${message}`))),
+  };
+}
+
+function checkPackagePeerDependencies(package, packages) {
+  const checkPackagePeers = step(`${package.name} peerDependency checks`);
+  checkPackagePeers.start();
+
+  getLernaPackages({ changed: true })
+    .filter(({ name }) => Object.keys(package?.peerDependencies ?? {}).includes(name))
+    .map(({ name }) => packages.find((pkg) => pkg.name === name))
+    .filter(Boolean)
+    .forEach((peerPackage) => {
+      try {
+        testPackage(package, peerPackage);
+      } catch (e) {
+        package.markBreakingPeer(peerPackage);
+        console.log(chalk.red(e));
+      }
+    });
+
+  console.log('');
+  if (package.breakingPeers.length) {
+    console.log('');
+    console.log(
+      chalk.yellow(
+        ` ⚠️  package ${package.name} has breaking peerDependencies: ${package.breakingPeers
+          .map(({ name }) => name)
+          .join(', ')}`,
+      ),
+    );
+    console.log('');
+  }
+
+  checkPackagePeers.stop();
+
+  console.log(chalk.blue('restoring package dependencies with yarn and re-linking'));
+  yarnAndLink();
+}
+
+function announceBrokenPeerDependencies(packages) {
+  console.log(chalk.yellow(`⚠️  Broken Peer Dependencies:`));
+  console.log(chalk.yellow(`----------------------------------------------------`));
+  packages.forEach((package) => {
+    if (!package.breakingPeers.length) {
+      return;
+    }
+
+    console.log(
+      chalk.yellow(
+        `package: ${package.name} with peer dependency: ${package.breakingPeers.map(({ name }) => name).join(', ')}`,
+      ),
+    );
+  });
+  console.log(chalk.yellow(`----------------------------------------------------`));
+}
+
+function testPackage(package, peerPackage) {
+  const range = package.peerDependencies[peerPackage.name];
+
+  const testPeerRange = step(`testing package ${package.name} with peer ${peerPackage.name}: ${range}`);
+  testPeerRange.start();
+
+  const testVersions = (peerPackage.publishedVersions ?? []).filter((version) => semver.satisfies(version, range));
+
+  try {
+    testVersions.forEach((version) => {
+      const testPeerVersion = step(`Testing ${package.name} with peer version ${peerPackage.name}@${version}`);
+      try {
+        testPeerVersion.start();
+        execSync(`yarn run lerna exec --scope ${package.name} "npm install --no-save ${peerPackage.name}@${version}"`);
+        execSync(`yarn run lerna run --scope ${package.name} test`);
+        testPeerVersion.stop();
+      } catch (e) {
+        testPeerVersion.error();
+        throw e;
+      }
+    });
+
+    testPeerRange.stop();
+  } catch (e) {
+    testPeerRange.error();
+    throw e;
+  }
+}
+
+function commitsSincePublish() {
+  const logs = execSync(`git log --oneline`).toString().split('\n');
+
+  const commits = [];
+  for (const line of logs) {
+    if (line.includes('Publish (#')) {
+      break;
+    }
+
+    const commit = line.substr(0, 7);
+    commits.push(commit);
+  }
+
+  return commits;
+}
+
+function attachChangelogs(packages) {
+  const commits = commitsSincePublish();
+  const messages = commits.map((commit) => execSync(`git log --format=%B -n 1 ${commit}`).toString());
+
+  const prNumbers = messages
+    .map((message) => {
+      message = message.trim();
+      const prRegEx = /\(#(\d+)\)/;
+      const prNumber = prRegEx.exec(message)?.[1];
+      return prNumber;
+    })
+    .filter(Boolean);
+
+  const changelogs = [];
+  prNumbers.forEach((prNum) => {
+    const pr = JSON.parse(execSync(`gh pr view ${prNum} --json body,title,number,url`).toString().trim());
+    const { body: content, title, number, url } = pr;
+    const changelogRegex = new RegExp(/```markdown changelog\((.*?)\)(.*?)```/, 'gms');
+
+    let result;
+    while ((result = changelogRegex.exec(content)) !== null) {
+      const [, package, entry] = result;
+      if (!package) {
+        throw new Error(`Expected specific package for changelog entry, got ${package} in :\n${content}`);
+      }
+      changelogs.push({ package, entry: entry.trim(), pr: { title, number, url } });
+    }
+  });
+
+  changelogs.forEach(({ package: packageName, entry, pr }) => {
+    const package = packages.find(({ name }) => name === packageName);
+    package.changelogEntries.push({ entry, pr });
+  });
+}
+
+function announcePackageChangelogs(packages) {
+  console.log();
+  console.log(chalk.blue('Package Changelogs'));
+  packages.forEach((package) => {
+    if (!package.changelogEntries.length) {
+      return;
+    }
+
+    console.log();
+    console.log(chalk.bold(package.name));
+    if (package.containsBreakingChange) {
+      console.log(chalk.red('** contains breaking change ** '));
+    }
+    console.log('\n---\n');
+    package.changelogEntries.forEach(({ entry, pr }) => {
+      console.log(`${pr.title} (#${pr.number})`);
+      console.log(`${pr.url}`);
+      console.log();
+      console.log(entry);
+      console.log('\n---\n');
+    });
+  });
+}
+
+function yarnBootstrap() {
+  console.log(chalk.blue('running yarn bootstrap'));
+  execSync(`yarn bootstrap`);
+  console.log(chalk.green('✅ finished running yarn bootstrap'));
+}
+
+function createReleaseBranch() {
   const commit = execSync('git rev-parse --short HEAD').toString().trim();
   execSync(`git checkout -b release-${commit}`);
-  execSync(`git push -u origin release-${commit}`);
+}
 
-  execSync('yarn lerna version --no-push', {
+function lernaVersion() {
+  execSync('yarn run lerna version --no-git-tag-version --no-push', {
     cwd: process.cwd(),
     env: process.env,
     stdio: 'inherit',
   });
+}
+
+function checkMainBranch() {
+  const currentBranch = execSync('git branch --show-current').toString().trim();
+  if (currentBranch !== 'main') {
+    console.error(chalk.red('  ⚠️ Ensure create-release is ran from the main branch '));
+    exit(-1);
+  }
+}
+
+function checkCleanBranch() {
+  // run yarn, if there are changes to yarn.lock then
+  // the clean working directory check will fail
+  console.log(chalk.blue('  Running yarn, to ensure no uncommitted changes to yarn.lock'));
+  execSync('yarn', { stdio: 'ignore' });
+
+  const cleanWorkingDirectory = execSync('git status --porcelain').toString().trim() === '';
+  if (!cleanWorkingDirectory) {
+    console.error(chalk.red('  ⚠️ Error: Ensure clean working directory before creating release pr '));
+    exit(-1);
+  }
+}
+
+function updatePeerDependencies(package, allPackages) {
+  Object.keys(package.peerDependencies).forEach((peerName) => {
+    const lernaPackageNames = getLernaPackages().map(({ name }) => name);
+    if (!lernaPackageNames.includes(peerName)) {
+      // peer package is not a managed graphql-mocks package, skip.
+      return;
+    }
+
+    const peer = allPackages.find(({ name }) => name === peerName);
+    const peerIsBreaking = Boolean(package.breakingPeers.find((breakingPeer) => breakingPeer.name === peer.name));
+    const currentPeerRange = package.peerDependencies[peerName];
+    const peerVersions = [...peer.publishedVersions, peer.version];
+    const updatedPeerRange = peerIsBreaking
+      ? `^${peer.version}`
+      : semver.simplifyRange(peerVersions, `${currentPeerRange} || ${peer.version}`);
+
+    package.peerDependencies[peer.name] = updatedPeerRange;
+  });
+}
+
+function createChangeLogEntries(packages) {
+  console.log(chalk.blue('Creating changelog entries'));
+  const changelogPath = path.resolve(__dirname, '../CHANGELOG.md');
+  let changelogContents = readFileSync(changelogPath).toString();
+
+  packages.forEach((package) => {
+    const packageHeading = `## ${package.name}`;
+    const hasExistingPackageEntries = changelogContents.includes(packageHeading);
+    const hasNewPackageEntries = package.changelogEntries.length > 0;
+
+    if (!hasNewPackageEntries) {
+      console.log(chalk.yellow(`No changelog entries for ${package.name}, skipping.`));
+      return;
+    }
+
+    const versionHeading = `### ${package.name}@${package.version}`;
+    const entries = package.changelogEntries.map(({ entry, pr }) => {
+      return `
+#### ${pr.title} ([#${pr.number}](${pr.url}))
+
+${entry}
+    `.trim();
+    });
+
+    const packageEntries = `${packageHeading}\n\n${versionHeading}\n\n${entries.join('\n\n')}`;
+
+    if (hasExistingPackageEntries) {
+      changelogContents = changelogContents.replace(packageHeading, packageEntries);
+    } else {
+      changelogContents = changelogContents.concat(`\n\n${packageEntries}`);
+    }
+
+    console.log(chalk.green(`✅ updated package entries for ${package.name}`));
+  });
+
+  console.log(chalk.green(`✅ wrote CHANGELOG.md`));
+  writeFileSync(changelogPath, changelogContents);
+}
+
+function commitChangesWithFormattedMessage(packages) {
+  const formattedPackageNames = packages
+    .filter((package) => package.previousVersion !== null)
+    .map((package) => {
+      return ` - ${package.name}@${package.version}`;
+    });
+
+  const commitMessage = `Publish\n\n${formattedPackageNames.join('\n')}`;
+  execSync(`git add .`);
+  execSync(`git commit -m "${commitMessage}"`);
+}
+
+class Package {
+  path;
+  name;
+  pjson;
+  containsBreakingChange = false;
+  changelogEntries = [];
+  publishedVersions = [];
+  breakingPeers = [];
+  previousVersion = null;
+
+  get version() {
+    return this.pjson?.version;
+  }
+
+  set version(value) {
+    this.pjson.version = value;
+  }
+
+  get peerDependencies() {
+    return this.pjson?.peerDependencies;
+  }
+
+  constructor({ path, name }) {
+    this.path = path;
+    this.name = name;
+    this.publishedVersions = getPublishedVersions(name);
+    this.loadPjson();
+  }
+
+  markBreakingPeer(peer) {
+    this.containsBreakingChange = true;
+    this.breakingPeers.push(peer);
+  }
+
+  loadPjson() {
+    const newPjson = require(`${this.path}/package.json`);
+    const newVersion = this.version !== newPjson.version;
+
+    if (newVersion) {
+      this.previousVersion = this.version;
+    }
+
+    this.pjson = newPjson;
+  }
+
+  write() {
+    const { path } = this;
+    writeFileSync(`${path}/package.json`, JSON.stringify(this.pjson, null, 2));
+  }
+}
+
+try {
+  yarnAndLink();
+  yarnBootstrap();
+  checkMainBranch();
+  checkCleanBranch();
+
+  const packages = getLernaPackages().map((lernaPackage) => {
+    const { name, location: path } = lernaPackage;
+    return new Package({ name, path });
+  });
+
+  packages.forEach((package) => checkPackagePeerDependencies(package, packages));
+  announceBrokenPeerDependencies(packages);
+  attachChangelogs(packages);
+  announcePackageChangelogs(packages);
+  createReleaseBranch();
+  lernaVersion();
+
+  // lerna version will have updated package.json versions
+  // the pjson loaded on each `Package` should be updated
+  packages.forEach((package) => package.loadPjson());
+
+  // update peer dependencies based on new package.json
+  // version numbers
+  packages.forEach((package) => updatePeerDependencies(package, packages));
+
+  // write peerDependency changes back to package.json
+  packages.forEach((package) => package.write());
+
+  createChangeLogEntries(packages);
+  commitChangesWithFormattedMessage(packages);
 } catch (e) {
-  console.log(e.message);
-  exit(-1);
+  console.log(chalk.red('An error occurred in creating the release:'));
+  console.log(chalk.red(e.message));
+  throw e;
 }

--- a/scripts/tag-releases.js
+++ b/scripts/tag-releases.js
@@ -3,7 +3,7 @@
 const { execSync } = require('child_process');
 
 function tagCommit(commit, tag) {
-  execSync(`git tag --force ${tag} ${commit}`, { stdio: 'ignore' });
+  execSync(`git tag -m ${tag} --force ${tag} ${commit}`, { stdio: 'ignore' });
 }
 
 function createGithubRelease(commit, tag) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5582,7 +5582,7 @@ chalk@^4.0.0, chalk@^4.1.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chalk@^4.1.1:
+chalk@^4.1.1, chalk@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
@@ -14672,6 +14672,13 @@ semver@^7.2.1, semver@^7.3.2:
   version "7.3.2"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
   integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
+
+semver@^7.3.5:
+  version "7.3.5"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
+  integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
+  dependencies:
+    lru-cache "^6.0.0"
 
 send@0.17.1:
   version "0.17.1"


### PR DESCRIPTION
This pull request improves the create-release script to:
* Run tests and find breaking changes with peer dependencies and then update peer dependency ranges
* Pull changelog entries from pull requests in the format of:

````markdown
```markdown changelog(graphql-mocks)
Testing changelog entry for package graphql-mocks. The package name in the parens specify which package the changelog entry is assigned to.
```
````

Fixes #70 
