### PR TITLE
Add pr template to make use of new changelog feature

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+<!--
+  Assign any relevent github labels, including the packages affected.
+-->
+
+## CHANGELOG
+
+<!--
+  Include any changelog entries one per package in a bulleted list
+  as a (feature), (fix) or (breaking) with breaking changes at the
+  top.
+
+  * (breaking) list breaking changes first
+  * (feature) added a new feature
+  * (fix) fixed bug
+-->
+
+```markdown changelog(package-name)
+* (feature) Added a new feature
+```


### PR DESCRIPTION
Since adding changelog support to the `create-release` script it is helpful to have the pull request template to take care of some of the boilerplate.