### PR TITLE
Fix create-release script

### DIFF
--- a/scripts/create-release.js
+++ b/scripts/create-release.js
@@ -343,10 +343,10 @@ class Package {
   }
 
   loadPjson() {
-    const newPjson = require(`${this.path}/package.json`);
-    const newVersion = this.version !== newPjson.version;
+    const newPjson = JSON.parse(readFileSync(`${this.path}/package.json`).toString());
+    const newVersionExists = this.version !== newPjson.version;
 
-    if (newVersion) {
+    if (newVersionExists) {
       this.previousVersion = this.version;
     }
 


### PR DESCRIPTION
After some testing it turns out the package.json wasn't being reloaded after lerna version bumping. This caused versio bumps to be overwritten with the original package.json and miss out on the new version and any peer dependency fixes. 

This bug was the result of loading the package.json using the `require` from node which caches the result. Instead of messaging with the cache system the loading of packge.json now loads directly from disk using the `fs` module.