### PR TITLE
Update READMEs and package documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,10 @@ Thank you for considering a contribution to graphql-mocks. Open source is always
 
 In most cases we want your contributions! This includes bug fixes, documentation tweaks, and your ideas. If you have a feature addition or improvement open an issue first or jump on Discord to discuss if it is a good fit for the project.
 
+### Local Development
+
+See the `DEVELOPMENT.md` doc for guidance on setting up and running this project locally
+
 ## Project Layout
 
 This project is using lerna and is a monorepo for several separate packages. You can find these packages in the `packages` folder.
@@ -16,7 +20,7 @@ Please double-check in an issue or by jumping on discord to discuss if a pull re
 
 ## Found a bug?
 
-Open an issue and let's chat.
+Open an issue and let's chat or start a conversation on discord.
 
 ## Respect
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,45 @@
+# Development
+
+This document covers how to locally develop on the GraphQL Mocks.
+
+## System Requirements
+
+* [git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+* [Node >= 12](https://nodejs.org/en/download/)
+* [`yarn`](https://yarnpkg.com/)
+
+## Repo Structure
+
+This repo is managed as a lerna monorepo. The packages are in the [`packages`](https://github.com/graphql-mocks/graphql-mocks/tree/main/packages) folder. Note that the name of the package might not directly correspond to the package name seen in the package.json (see the [`packages list`](http://www.graphql-mocks.com/packages) for a concrete mapping).
+
+## Getting Started
+
+Clone the repo, then:
+
+1. Run `yarn` to setup packages
+2. Run `yarn bootstrap` to bootstrap package dependencies
+
+⚠️ Note: Any time a new package is added via `yarn`, run `yarn link-packages` to re-establish symlinks between packages (see below).
+
+## Monorepo Cross-Dependencies & Package Symlinking
+
+Each package's cross-dependencies (that is a dependency on a package that is within the monorepo) are setup to be linked to the final built form of the cross-dependency. This is done by default with `yarn bootstrap` but can be re-established with `yarn link-packages` ran from the root of the monorepo. This is especially useful to get any updates to typescript typings as well as testing against a more "final version" of the package.
+
+For example, the `@graphql-mocks/sinon` package has a cross-dependency on the core `graphql-mocks` package, and after running `yarn link-packages` a symlink wold be created at `packages/sinon/node_modules/graphql-mocks` pointing to `packages/graphql-mocks/dist`.
+
+### Modifying Upsteam GraphQL Mock Packages
+
+When making changes to multiple packages it's important to keep any upstream dependencies `dist` folders freshly compiled, or built, with those changes. To do this run `yarn watch` from the upstream cross-dependency which will monitor for any file changes and update `dist` with the latest changes.
+
+Continuing the previous example where the `@graphql-mocks/sinon` package has a cross-dependency on the core `graphql-mocks` package. If a change was being made to `graphql-mocks` that should be tested or developed against a downstream dependency, like `@graphql-mocks/sinon`, then the following steps would help for local development:
+
+1. Run `yarn watch` in the root folder for `graphql-mocks` (keeping its symlinked `dist` updated)
+2. Make necessary changes to `graphql-mocks` or `@graphql-mocks/sinon`
+3. Run tests on `@graphql-mocks/sinon` via `yarn --watch`
+
+## Testing All Monorepo Packages Together
+
+To test all the packages together, from the repo root:
+
+1. Run `yarn bootstrap` (ensure fresh builds across all the packages)
+2. Run `yarn test` (runs the test command in each package)

--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
 <p align="center">
   <img width="350" src="./packages/docs/static/img/logo.svg" />
   <h1 align="center">GraphQL Mocks</h1>
+  <div align="center">
+    <a href="https://github.com/graphql-mocks/graphql-mocks/blob/main/CHANGELOG.md">Changelog</a> | <a href="https://github.com/graphql-mocks/graphql-mocks/blob/main/CONTRIBUTING.md">Contributing</a> | <a href="https://github.com/graphql-mocks/graphql-mocks/blob/main/DEVELOPMENT.md">Development</a> | <a href="http://www.graphql-mocks.com/packages">Packages & API</a>
+  </div>
 </p>
-
-* [Changelog](https://github.com/graphql-mocks/graphql-mocks/blob/main/CHANGELOG.md)
-* [Contributing](https://github.com/graphql-mocks/graphql-mocks/blob/main/CONTRIBUTING.md)
-* [Development](https://github.com/graphql-mocks/graphql-mocks/blob/main/DEVELOPMENT.md)
-* [Packages & API](http://www.graphql-mocks.com/packages)
 
 👋 Hello and welcome to GraphQL Mocks.
 

--- a/README.md
+++ b/README.md
@@ -1,30 +1,17 @@
 <p align="center">
   <img width="350" src="./packages/docs/static/img/logo.svg" />
-  <h1 align="center">graphql-mocks</h1>
+  <h1 align="center">GraphQL Mocks</h1>
 </p>
 
-## 👋 Welcome
+* [Changelog](https://github.com/graphql-mocks/graphql-mocks/blob/main/CHANGELOG.md)
+* [Contributing](https://github.com/graphql-mocks/graphql-mocks/blob/main/CONTRIBUTING.md)
+* [Development](https://github.com/graphql-mocks/graphql-mocks/blob/main/DEVELOPMENT.md)
+* [Packages & API](http://www.graphql-mocks.com/packages)
 
-Hello, you've reached the lerna mono repo for `graphql-mocks`.
+👋 Hello and welcome to GraphQL Mocks.
 
-Check out the [website](https://www.graphql-mocks.com) for an introduction on getting started with graphql-mocks.
+GraphQL Mocks is a set of libraries and tools to provide full end-to-end GraphQL mocking for node, the browser, and even as a `localhost` server.
 
-The individual packages hosted in this repo can be found in the `packages` folder, they include:
+This github repo contains the source code for the main [core packages](http://www.graphql-mocks.com/packages).
 
-- `graphql-mocks` (folder: `graphql-mocks`) — The main package containing graphql-mocks core functionality
-- `graphql-paper` (folder: `paper`) - GraphQL Paper, an in-memory store using GraphQL schema. Can be used on its own without graphql-mocks.
-- `@graphql-mocks/sinon` (folder: `sinon`) - Sinon spy integration with graphql-mocks, useful for test scenarios
-- `@graphql-mocks/mirage` (folder: `mirage`) - Mirage.js integration with graphql-mocks, automatically resolve data with Mirage
-- `@graphql-mocks/docs` (folder: `docs`) — Contains the documentation published at [www.graphql-mocks.com](https://www.graphql-mocks.com)
-
-## 🏗 Developing
-
-Clone the repo, then:
-
-1. Run `yarn` to setup packages
-2. Run `yarn bootstrap` to bootstrap package dependencies
-3. Run `yarn link-packages` to cross-link packages within monorepo to respective package's `dist` folder
-
-If changes are isolated to a single package then you should be all set.
-
-If changes are in multiple packages where there is a dependency then changes will need to be rebuilt in dependent packages. Cross-dependencies are linked to `dist` folder in the dependency package-specific root (`package/*`) folder. It can be rebuilt by running `yarn build` in the dependency's root folder or `yarn bootstrap` from the monorepo root which rebuilds for all packages and is much slower.
+Check out the [website](https://www.graphql-mocks.com) for more information.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -75,9 +75,10 @@
     "postpack": "rm -f oclif.manifest.json",
     "prepack": "rm -rf lib && oclif readme && yarn build",
     "test": "NODE_ENV=development mocha \"test/**/*.test.ts\"",
-    "build": "tsc && yarn copy-blueprints && oclif manifest",
+    "build": "tsc && yarn copy-blueprints && yarn copy-readme && oclif manifest",
     "test-build": "mocha \"test/**/*.test.ts\"",
-    "copy-blueprints": "mkdir -p lib/blueprints && cp -r src/blueprints lib"
+    "copy-blueprints": "mkdir -p lib/blueprints && cp -r src/blueprints lib",
+    "copy-readme": "cp README.md lib/README.md"
   },
   "types": "lib/index.d.ts"
 }

--- a/packages/docs/.gitignore
+++ b/packages/docs/.gitignore
@@ -21,6 +21,3 @@ static/api/*
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
-
-## typedoc-package generated
-static/api

--- a/packages/docs/docusaurus.config.js
+++ b/packages/docs/docusaurus.config.js
@@ -35,8 +35,8 @@ module.exports = {
           position: 'right',
         },
         {
-          href: '/api',
-          label: 'API',
+          href: '/packages',
+          label: 'Packages & API',
           position: 'right',
         },
         {

--- a/packages/docs/src/pages/packages.jsx
+++ b/packages/docs/src/pages/packages.jsx
@@ -10,7 +10,7 @@ function ApiLink({ directoryName, packageName }) {
   );
 }
 
-function Home() {
+function Packages() {
   const context = useDocusaurusContext();
   const { siteConfig = {} } = context;
   return (

--- a/packages/docs/src/pages/packages.jsx
+++ b/packages/docs/src/pages/packages.jsx
@@ -2,11 +2,23 @@ import React from 'react';
 import Layout from '@theme/Layout';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 
-function ApiLink({ directoryName, packageName }) {
+function Package({ directoryName, packageName, apiDocsHref }) {
+  apiDocsHref = apiDocsHref ?? `/api/${directoryName}`;
+
   return (
-    <a href={`/api/${directoryName}`}>
-      <code>{packageName}</code>
-    </a>
+    <>
+      <td>
+        <a href={`https://www.npmjs.com/package/${packageName}`}>
+          <code>{packageName}</code>
+        </a>
+      </td>
+      <td>
+        <a href={`https://github.com/graphql-mocks/graphql-mocks/tree/main/packages/${directoryName}`}>
+          <code>/packages/{directoryName}</code>
+        </a>
+      </td>
+      <td>{apiDocsHref ? <a href={apiDocsHref}>API</a> : 'none'}</td>
+    </>
   );
 }
 
@@ -17,40 +29,51 @@ function Packages() {
     <Layout title="Home" description={siteConfig.tagline}>
       <div className="container">
         <header style={{ marginTop: '2rem' }}>
-          <h1>Typescript API Documentation</h1>
+          <h1>Packages &#38; API</h1>
         </header>
         <main>
-          <h2>Packages</h2>
-          <ul>
-            <li>
-              <ApiLink directoryName="graphql-mocks" packageName="graphql-mocks" />
-            </li>
-            <li>
-              <ApiLink directoryName="paper" packageName="graphql-paper" />
-            </li>
-            <li>
-              <ApiLink directoryName="network-msw" packageName="@graphql-mocks/network-msw" />
-            </li>
-            <li>
-              <ApiLink directoryName="network-nock" packageName="@graphql-mocks/network-nock" />
-            </li>
-            <li>
-              <ApiLink directoryName="network-express" packageName="@graphql-mocks/network-express" />
-            </li>
-            <li>
-              <ApiLink directoryName="faker" packageName="@graphql-mocks/faker" />
-            </li>
-            <li>
-              <ApiLink directoryName="sinon" packageName="@graphql-mocks/sinon" />
-            </li>
-            <li>
-              <ApiLink directoryName="mirage" packageName="@graphql-mocks/mirage" />
-            </li>
-          </ul>
+          <table>
+            <thead>
+              <tr>
+                <td>Package Name</td>
+                <td>Package Source</td>
+                <td>API Documentation</td>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <Package directoryName="graphql-mocks" packageName="graphql-mocks" />
+              </tr>
+              <tr>
+                <Package directoryName="paper" packageName="graphql-paper" />
+              </tr>
+              <tr>
+                <Package directoryName="network-msw" packageName="@graphql-mocks/network-msw" />
+              </tr>
+              <tr>
+                <Package directoryName="network-nock" packageName="@graphql-mocks/network-nock" />
+              </tr>
+              <tr>
+                <Package directoryName="network-express" packageName="@graphql-mocks/network-express" />
+              </tr>
+              <tr>
+                <Package directoryName="cli" packageName="gqlmocks" apiDocsHref="/docs/cli/commands" />
+              </tr>
+              <tr>
+                <Package directoryName="faker" packageName="@graphql-mocks/faker" />
+              </tr>
+              <tr>
+                <Package directoryName="sinon" packageName="@graphql-mocks/sinon" />
+              </tr>
+              <tr>
+                <Package directoryName="mirage" packageName="@graphql-mocks/mirage" />
+              </tr>
+            </tbody>
+          </table>
         </main>
       </div>
     </Layout>
   );
 }
 
-export default Home;
+export default Packages;

--- a/packages/faker/README.md
+++ b/packages/faker/README.md
@@ -1,0 +1,11 @@
+# `@graphql-mocks/faker`
+
+This package provides a faker middleware and field resolver that can be used, along with the core `graphql-mocks` package, to automatically mock data with some applied heuristics, too. For more information and examples check out the [documentation](http://www.graphql-mocks.com/docs/guides/faker).
+
+---
+
+* [GraphQL Mocks](http://www.graphql-mocks.com)
+* [API Documentation](http://www.graphql-mocks.com/api/faker/)
+* [`@graphql-mocks/faker` documentation](http://www.graphql-mocks.com/docs/guides/faker)
+* References
+  * [Introducing Resolver Map Middlewares](http://www.graphql-mocks.com/docs/resolver-map/introducing-middlewares)

--- a/packages/faker/package.json
+++ b/packages/faker/package.json
@@ -13,7 +13,8 @@
     "test": "TS_NODE_PROJECT=\"./test/tsconfig.json\" mocha -r ts-node/register \"./test/**/*.test.ts\"",
     "clean": "rimraf ./dist",
     "copy-pjson": "node scripts/copy-scrubbed-pjson",
-    "build": "yarn clean && rollup -c rollup.config.js && yarn copy-pjson",
+    "copy-readme": "cp README.md dist/README.md",
+    "build": "yarn clean && rollup -c rollup.config.js && yarn copy-pjson && yarn copy-readme",
     "watch": "rollup --watch -c rollup-watch.config.js"
   },
   "publishConfig": {

--- a/packages/graphql-mocks/README.md
+++ b/packages/graphql-mocks/README.md
@@ -1,0 +1,19 @@
+# `graphql-mocks`
+
+The core package for `graphql-mocks` includes core primitives used for mocking a GraphQL API, including:
+* GraphQL Handler
+* Resolver Map Middlewares
+* Resolver Wrappers
+* Highlight
+
+---
+
+* [GraphQL Mocks](http://www.graphql-mocks.com)
+* [API Documentation](http://www.graphql-mocks.com/api/graphql-mocks/)
+* References
+  * [Introducing the GraphQL Handler](http://www.graphql-mocks.com/docs/handler/introducing-handler)
+  * [Using Resolvers](http://www.graphql-mocks.com/docs/resolver/using-resolvers)
+  * [Introducing Resolver Wrappers](http://www.graphql-mocks.com/docs/resolver/introducing-wrappers)
+  * [Using Resolver Maps](http://www.graphql-mocks.com/docs/resolver-map/using-resolver-maps)
+  * [Introducing Resolver Map Middlewares](http://www.graphql-mocks.com/docs/resolver-map/introducing-middlewares)
+  * [Introducing Highlight](http://www.graphql-mocks.com/docs/highlight/introducing-highlight)

--- a/packages/graphql-mocks/package.json
+++ b/packages/graphql-mocks/package.json
@@ -13,7 +13,8 @@
     "test": "TS_NODE_PROJECT=\"./test/tsconfig.json\" mocha -r ts-node/register \"./test/**/*.test.ts\"",
     "clean": "rimraf ./dist",
     "copy-pjson": "node scripts/copy-scrubbed-pjson",
-    "build": "yarn clean && rollup -c rollup.config.js && yarn copy-pjson",
+    "copy-readme": "cp README.md dist/README.md",
+    "build": "yarn clean && rollup -c rollup.config.js && yarn copy-pjson && yarn copy-readme",
     "watch": "rollup --watch -c rollup-watch.config.js"
   },
   "publishConfig": {

--- a/packages/mirage/README.md
+++ b/packages/mirage/README.md
@@ -1,0 +1,12 @@
+# `@graphql-mocks/mirage`
+
+This package was created to provide integrations with existing mocking environments that used [mirage.js](https://miragejs.com) for holding stateful data while mocking. If starting in a new project it is instead recommended to use [GraphQL Paper](http://www.graphql-mocks.com/docs/paper/introducing-paper), a GraphQL-first store, that is more robust when it comes to handling GraphQL data and integrating with GraphQL Mocks.
+
+---
+
+* [GraphQL Mocks](http://www.graphql-mocks.com)
+* [API Documentation](http://www.graphql-mocks.com/api/mirage/)
+* [`@graphql-mocks/mirage` documentation](http://www.graphql-mocks.com/docs/guides/mirage-js) 
+* References
+  * [GraphQL Paper](http://www.graphql-mocks.com/docs/paper/introducing-paper)
+  * [GraphQL Paper with `graphql-mocks`](http://www.graphql-mocks.com/docs/guides/paper)

--- a/packages/mirage/package.json
+++ b/packages/mirage/package.json
@@ -13,7 +13,8 @@
     "test": "TS_NODE_PROJECT=\"./test/tsconfig.json\" mocha -r ts-node/register \"./test/**/*.test.ts\"",
     "clean": "rimraf ./dist",
     "copy-pjson": "node scripts/copy-scrubbed-pjson",
-    "build": "yarn clean && rollup -c rollup.config.js && yarn copy-pjson",
+    "copy-readme": "cp README.md dist/README.md",
+    "build": "yarn clean && rollup -c rollup.config.js && yarn copy-pjson && yarn copy-readme",
     "watch": "rollup --watch -c rollup-watch.config.js"
   },
   "publishConfig": {

--- a/packages/network-express/README.md
+++ b/packages/network-express/README.md
@@ -1,0 +1,12 @@
+# `@graphql-mocks/network-express`
+
+This package provides the [Network Handler](http://www.graphql-mocks.com/docs/network/introducing-network-handlers) in the form of an express middleware for integrating GraphQL Mocks with [express.js](https://expressjs.com).
+
+---
+
+* [GraphQL Mocks](http://www.graphql-mocks.com)
+* [API Documentation](http://www.graphql-mocks.com/api/network-express/)
+* [`@graphql-mocks/network-express` documentation](http://www.graphql-mocks.com/docs/network/express) 
+* References
+  * [Introducing Network Handlers](http://www.graphql-mocks.com/docs/network/introducing-network-handlers)
+  * [Express.js](https://expressjs.com)

--- a/packages/network-express/package.json
+++ b/packages/network-express/package.json
@@ -13,7 +13,8 @@
     "test": "TS_NODE_PROJECT=\"./test/tsconfig.json\" mocha -r ts-node/register \"./test/**/*.test.ts\"",
     "clean": "rimraf ./dist",
     "copy-pjson": "node scripts/copy-scrubbed-pjson",
-    "build": "yarn clean && rollup -c rollup.config.js && yarn copy-pjson",
+    "copy-readme": "cp README.md dist/README.md",
+    "build": "yarn clean && rollup -c rollup.config.js && yarn copy-pjson && yarn copy-readme",
     "watch": "rollup --watch -c rollup-watch.config.js"
   },
   "publishConfig": {

--- a/packages/network-msw/README.md
+++ b/packages/network-msw/README.md
@@ -1,0 +1,12 @@
+# `@graphql-mocks/network-msw`
+
+This package provides a [Network Handler](http://www.graphql-mocks.com/docs/network/introducing-network-handlers) in the form of a msw route handler to integrate GraphQL Mocks with [msw (mock service worker)](https://mswjs.io). This method allows for full GraphQL Mocking in the browser.
+
+---
+
+* [GraphQL Mocks](http://www.graphql-mocks.com)
+* [API Documentation](http://www.graphql-mocks.com/api/network-msw)
+* [`@graphql-mocks/network-msw` documentation](http://www.graphql-mocks.com/docs/network/msw) 
+* References
+  * [Introducing Network Handlers](http://www.graphql-mocks.com/docs/network/introducing-network-handlers)
+  * [msw (mock service worker)](https://mswjs.io)

--- a/packages/network-msw/package.json
+++ b/packages/network-msw/package.json
@@ -13,7 +13,8 @@
     "test": "TS_NODE_PROJECT=\"./test/tsconfig.json\" mocha -r ts-node/register \"./test/**/*.test.ts\"",
     "clean": "rimraf ./dist",
     "copy-pjson": "node scripts/copy-scrubbed-pjson",
-    "build": "yarn clean && rollup -c rollup.config.js && yarn copy-pjson",
+    "copy-readme": "cp README.md dist/README.md",
+    "build": "yarn clean && rollup -c rollup.config.js && yarn copy-pjson && yarn copy-readme",
     "watch": "rollup --watch -c rollup-watch.config.js"
   },
   "publishConfig": {

--- a/packages/network-nock/README.md
+++ b/packages/network-nock/README.md
@@ -1,0 +1,12 @@
+# `@graphql-mocks/network-nock`
+
+This package provides a [Network Handler](http://www.graphql-mocks.com/docs/network/introducing-network-handlers) in the form of a Nock route handler to integrate GraphQL Mocks with [Nock](https://github.com/nock/nock). This allows for writing mocks in tests against Nock, node-based network mocking.
+
+---
+
+* [GraphQL Mocks](http://www.graphql-mocks.com)
+* [API Documentation](http://www.graphql-mocks.com/api/network-nock/)
+* [`@graphql-mocks/network-nock` documentation](http://www.graphql-mocks.com/docs/network/nock) 
+* References
+  * [Introducing Network Handlers](http://www.graphql-mocks.com/docs/network/introducing-network-handlers)
+  * [Nock](https://github.com/nock/nock) 

--- a/packages/network-nock/package.json
+++ b/packages/network-nock/package.json
@@ -13,7 +13,8 @@
     "test": "TS_NODE_PROJECT=\"./test/tsconfig.json\" mocha -r ts-node/register \"./test/**/*.test.ts\"",
     "clean": "rimraf ./dist",
     "copy-pjson": "node scripts/copy-scrubbed-pjson",
-    "build": "yarn clean && rollup -c rollup.config.js && yarn copy-pjson",
+    "copy-readme": "cp README.md dist/README.md",
+    "build": "yarn clean && rollup -c rollup.config.js && yarn copy-pjson && yarn copy-readme",
     "watch": "rollup --watch -c rollup-watch.config.js"
   },
   "publishConfig": {

--- a/packages/paper/README.md
+++ b/packages/paper/README.md
@@ -1,0 +1,38 @@
+# `graphql-paper`
+
+GraphQL Paper provides a stateful way of storing data in an in-memory store based on a GraphQL Schema. For a complete end-to-end mocking experience use GraphQL Paper with [GraphQL Mocks](http://www.graphql-mocks.com).
+
+Features:
+* Built and based on GraphQL
+* Works in the Browser and Node JS
+* Works without `graphql-mocks` with support for the official default GraphQL resolvers
+* Support and integration with `graphql-mocks`
+* Written in TypeScript
+* Support for relationships and connections between types
+* Immutable
+* Accessible via native js APIs
+* Hooks
+* Events
+* Transaction Operations
+* Validations
+
+See the [documentation](http://www.graphql-mocks.com/docs/paper/introducing-paper) for more information.
+
+---
+
+* [GraphQL Mocks](http://www.graphql-mocks.com)
+* [API Documentation](http://www.graphql-mocks.com/api/paper/)
+* [`graphql-paper` documentation](http://www.graphql-mocks.com/docs/paper/introducing-paper)
+* References
+  * [Using GraphQL Paper with GraphQL Mocks](http://www.graphql-mocks.com/docs/guides/paper)
+  * [Introducing GraphQL Paper](http://www.graphql-mocks.com/docs/paper/introducing-paper) 
+  * [Querying Data](http://www.graphql-mocks.com/docs/paper/querying-data) 
+  * [Mutating Data](http://www.graphql-mocks.com/docs/paper/mutating-data)
+  * [Operations](http://www.graphql-mocks.com/docs/paper/operations)
+  * [Events](http://www.graphql-mocks.com/docs/paper/events)
+  * [Hooks](http://www.graphql-mocks.com/docs/paper/hooks)
+  * [Validations](http://www.graphql-mocks.com/docs/paper/validations)
+  * [http://www.graphql-mocks.com/docs/paper/technical-notes](Technical Notes)
+  * [Generating Data with Factories](http://www.graphql-mocks.com/docs/paper/guides/factories)
+  * [Using GraphQL Paper with GraphQL](http://www.graphql-mocks.com/docs/paper/guides/with-graphql)
+  * [Managing IDs](http://www.graphql-mocks.com/docs/paper/guides/managing-ids)

--- a/packages/paper/package.json
+++ b/packages/paper/package.json
@@ -13,7 +13,8 @@
     "test": "TS_NODE_PROJECT=\"./test/tsconfig.json\" mocha -r \"event-target-polyfill\" -r ts-node/register \"./test/**/*.test.ts\"",
     "clean": "rimraf ./dist",
     "copy-pjson": "node scripts/copy-scrubbed-pjson",
-    "build": "yarn clean && rollup -c rollup.config.js && yarn copy-pjson",
+    "copy-readme": "cp README.md dist/README.md",
+    "build": "yarn clean && rollup -c rollup.config.js && yarn copy-pjson && yarn copy-readme",
     "watch": "rollup --watch -c rollup-watch.config.js"
   },
   "publishConfig": {

--- a/packages/sinon/README.md
+++ b/packages/sinon/README.md
@@ -1,0 +1,12 @@
+# `@graphql-mocks/sinon`
+
+This package provides a Resolver Wrapper for installing [sinon spies](https://sinonjs.org/releases/latest/spies/) on specified resolvers. This is useful during testing to assert that resolvers were called a certain number of times or called with certain arguments, or other features provided by sinon. See the [documentation](http://www.graphql-mocks.com/docs/resolver/available-wrappers#spy-wrapper) on how to access and use the spies.
+
+---
+
+* [GraphQL Mocks](http://www.graphql-mocks.com)
+* [API Documentation](http://www.graphql-mocks.com/api/sinon/)
+* References
+  * [`@graphql-mocks/sinon` documentation](http://www.graphql-mocks.com/docs/resolver/available-wrappers#spy-wrapper)
+  * [Introducing Resolver Wrappers](http://www.graphql-mocks.com/docs/resolver/introducing-wrappers)
+  * [Sinon.js](https://sinonjs.org)

--- a/packages/sinon/package.json
+++ b/packages/sinon/package.json
@@ -13,7 +13,8 @@
     "test": "TS_NODE_PROJECT=\"./test/tsconfig.json\" mocha -r ts-node/register \"./test/**/*.test.ts\"",
     "clean": "rimraf ./dist",
     "copy-pjson": "node scripts/copy-scrubbed-pjson",
-    "build": "yarn clean && rollup -c rollup.config.js && yarn copy-pjson",
+    "copy-readme": "cp README.md dist/README.md",
+    "build": "yarn clean && rollup -c rollup.config.js && yarn copy-pjson && yarn copy-readme",
     "watch": "rollup --watch -c rollup-watch.config.js"
   },
   "publishConfig": {

--- a/scripts/create-release.js
+++ b/scripts/create-release.js
@@ -244,7 +244,7 @@ function checkCleanBranch() {
 }
 
 function updatePeerDependencies(package, allPackages) {
-  Object.keys(package.peerDependencies ?? {}).forEach((peerName) => {
+  Object.keys(package.peerDependencies || {}).forEach((peerName) => {
     const lernaPackageNames = getLernaPackages().map(({ name }) => name);
     if (!lernaPackageNames.includes(peerName)) {
       // peer package is not a managed graphql-mocks package, skip.
@@ -366,23 +366,23 @@ class Package {
 }
 
 try {
-  // checkMainBranch();
-  // checkCleanBranch();
-  // createReleaseBranch();
-  // yarnAndLink();
-  // yarnBootstrap();
+  checkMainBranch();
+  checkCleanBranch();
+  createReleaseBranch();
+  yarnAndLink();
+  yarnBootstrap();
 
   const packages = getLernaPackages().map((lernaPackage) => {
     const { name, location: path } = lernaPackage;
     return new Package({ name, path });
   });
 
-  // packages.forEach((package) => checkPackagePeerDependencies(package, packages));
-  // announceBrokenPeerDependencies(packages);
-  // attachChangelogs(packages);
-  // announcePackageChangelogs(packages);
+  packages.forEach((package) => checkPackagePeerDependencies(package, packages));
+  announceBrokenPeerDependencies(packages);
+  attachChangelogs(packages);
+  announcePackageChangelogs(packages);
 
-  // lernaVersion();
+  lernaVersion();
 
   // lerna version will have updated package.json versions
   // the pjson loaded on each `Package` should be updated

--- a/templates/new-package/README.md
+++ b/templates/new-package/README.md
@@ -2,6 +2,8 @@
 
 **REPLACE ME**(PACKAGE DESCRIPTION)
 
+---
+
 * [GraphQL Mocks](http://www.graphql-mocks.com)
 * [API Documentation](**REPLACE ME**)
 * References

--- a/templates/new-package/README.md
+++ b/templates/new-package/README.md
@@ -1,0 +1,8 @@
+# `**REPLACE ME**(PACKAGE NAME)`
+
+**REPLACE ME**(PACKAGE DESCRIPTION)
+
+* [GraphQL Mocks](http://www.graphql-mocks.com)
+* [API Documentation](**REPLACE ME**)
+* References
+  * [**REPLACE ME**](**REPLACE ME**) 


### PR DESCRIPTION
To improve discoverability across the project this pull request adds links to the packages source code, npm page, and api documentation. It also adds READMEs in each package so there is content published with the package for anyone searching from the npm side.

Fixes #69 

- [x] Update root `README.md`
- [x] Rename *API* page to *Packages & API* and update page with package links
- [x] Update build script to copy in `README.md` into `dist` folder
- [x] Add `README.md` template in package template
- [x] Add `README.md` for each existing package (or adapting the previous to new format)

## CHANGELOG

### `graphql-mocks`
```markdown changelog(graphql-mocks)
* (feature) Added package README
```
### `graphql-paper`
```markdown changelog(graphql-paper)
* (feature) Added package README
```
### `@graphql-mocks/sinon`
```markdown changelog(@graphql-mocks/sinon)
* (feature) Added package README
```
### `@graphql-mocks/network-express`
```markdown changelog(@graphql-mocks/network-express)
* (feature) Added package README
```
### `@graphql-mocks/network-nock`
```markdown changelog(@graphql-mocks/network-nock)
* (feature) Added package README
```
### `@graphql-mocks/network-msw`
```markdown changelog(@graphql-mocks/network-msw)
* (feature) Added package README
```
### `@graphql-mocks/network-express`
```markdown changelog(@graphql-mocks/network-express)
* (feature) Added package README
```
### `@graphql-mocks/mirage`
```markdown changelog(@graphql-mocks/mirage)
* (feature) Added package README
```