### PR TITLE
Use lodash-es

### DIFF
--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -53,7 +53,7 @@
     "core-js": "^3.6.5",
     "event-target-polyfill": "^0.0.3",
     "globby": "^11.0.1",
-    "lodash.uniq": "^4.5.0",
+    "lodash-es": "^4.17.21",
     "mocha": "^8.0.1",
     "prettier": "^2.0.5",
     "react-syntax-highlighter": "^15.4.3",

--- a/packages/graphql-mocks/package.json
+++ b/packages/graphql-mocks/package.json
@@ -25,15 +25,7 @@
     "node": ">= 12.0.0"
   },
   "dependencies": {
-    "lodash.clonedeep": "^4.5.0",
-    "lodash.difference": "^4.5.0",
-    "lodash.differencewith": "^4.5.0",
-    "lodash.flattendepth": "^4.7.0",
-    "lodash.intersection": "^4.4.0",
-    "lodash.isequal": "^4.5.0",
-    "lodash.isequalwith": "^4.4.0",
-    "lodash.merge": "^4.6.2",
-    "lodash.mergewith": "^4.6.2"
+    "lodash-es": "^4.17.21"
   },
   "peerDependencies": {
     "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
@@ -42,16 +34,7 @@
     "sinon": "^9.0.0"
   },
   "devDependencies": {
-    "@types/lodash.clonedeep": "^4.5.6",
-    "@types/lodash.difference": "^4.5.6",
-    "@types/lodash.differencewith": "^4.5.6",
-    "@types/lodash.flattendepth": "^4.7.6",
-    "@types/lodash.intersection": "^4.4.6",
-    "@types/lodash.isequal": "^4.5.5",
-    "@types/lodash.isequalwith": "^4.4.6",
-    "@types/lodash.merge": "^4.6.6",
-    "@types/lodash.mergewith": "^4.6.6",
-    "@types/sinon": "^10.0.2",
+    "@types/lodash-es": "^4.17.6",
     "miragejs": "^0.1.40",
     "sinon": "^9.0.0"
   }

--- a/packages/graphql-mocks/src/highlight/highlight.ts
+++ b/packages/graphql-mocks/src/highlight/highlight.ts
@@ -1,5 +1,5 @@
 import { GraphQLSchema } from 'graphql';
-import clone from 'lodash.clonedeep';
+import { clone } from 'lodash-es';
 import { include } from './operation/include';
 import { exclude } from './operation/exclude';
 import { filter } from './operation/filter';

--- a/packages/graphql-mocks/src/highlight/highlighter/resolves-to.ts
+++ b/packages/graphql-mocks/src/highlight/highlighter/resolves-to.ts
@@ -8,7 +8,7 @@ import {
   GraphQLObjectType,
 } from 'graphql';
 import { HighlighterFactory, Highlighter, FieldReference } from '../types';
-import isEqualWith from 'lodash.isequalwith';
+import { isEqualWith } from 'lodash-es';
 import { HIGHLIGHT_ALL } from './constants';
 
 function concat<T>(a: T[], b: T[]): T[] {

--- a/packages/graphql-mocks/src/highlight/operation/exclude.ts
+++ b/packages/graphql-mocks/src/highlight/operation/exclude.ts
@@ -1,4 +1,4 @@
-import differenceWith from 'lodash.differencewith';
+import { differenceWith } from 'lodash-es';
 import { Reference } from '../types';
 import { isEqual } from '../utils/is-equal';
 

--- a/packages/graphql-mocks/src/highlight/utils/unique.ts
+++ b/packages/graphql-mocks/src/highlight/utils/unique.ts
@@ -1,5 +1,5 @@
 import { Reference } from '../types';
-import isEqual from 'lodash.isequal';
+import { isEqual } from 'lodash-es';
 
 export function unique(fieldReferences: Reference[]): Reference[] {
   const uniques: Reference[] = [];

--- a/packages/graphql-mocks/src/pack/pack.ts
+++ b/packages/graphql-mocks/src/pack/pack.ts
@@ -1,4 +1,4 @@
-import cloneDeep from 'lodash.clonedeep';
+import { cloneDeep } from 'lodash-es';
 import { embed } from '../resolver-map/embed';
 import { embedPackOptionsWrapper } from './utils';
 import { PackOptions, Packer, PackState } from './types';

--- a/packages/graphql-mocks/src/resolver-map/layer.ts
+++ b/packages/graphql-mocks/src/resolver-map/layer.ts
@@ -1,7 +1,7 @@
 import { ResolverMapMiddleware, ResolverMap, ObjectField } from '../types';
 import { ReplaceableResolverOption, WrappableOption } from './types';
 import { pack } from '../pack';
-import merge from 'lodash.merge';
+import { merge } from 'lodash-es';
 import { hi, fromResolverMap } from '../highlight';
 import { GraphQLSchema, GraphQLObjectType, GraphQLAbstractType } from 'graphql';
 import { walk } from '../highlight/utils';

--- a/packages/mirage/package.json
+++ b/packages/mirage/package.json
@@ -25,10 +25,10 @@
     "node": ">= 12.0.0"
   },
   "dependencies": {
-    "lodash.intersection": "^4.4.0"
+    "lodash-es": "^4.17.21"
   },
   "devDependencies": {
-    "@types/lodash.intersection": "^4.4.6",
+    "@types/lodash-es": "^4.17.6",
     "@types/sinon": "^10.0.2",
     "graphql-mocks": "^0.8.3",
     "miragejs": "^0.1.40",

--- a/packages/mirage/src/utils.ts
+++ b/packages/mirage/src/utils.ts
@@ -1,4 +1,4 @@
-import intersection from 'lodash.intersection';
+import { intersection } from 'lodash-es';
 import {
   GraphQLEnumType,
   GraphQLInputObjectType,

--- a/packages/paper/package.json
+++ b/packages/paper/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "immer": "^9.0.6",
     "just-diff": "^3.1.1",
-    "lodash.merge": "^4.6.2",
+    "lodash-es": "^4.17.21",
     "short-unique-id": "^4.3.3"
   },
   "peerDependencies": {
@@ -37,6 +37,7 @@
     "event-target-polyfill": "^0.0.3"
   },
   "devDependencies": {
+    "@types/lodash-es": "^4.17.6",
     "graphql-mocks": "^0.8.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4791,66 +4791,10 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.6.tgz#f4c7ec43e81b319a9815115031709f26987891f0"
   integrity sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==
 
-"@types/lodash.clonedeep@^4.5.6":
-  version "4.5.6"
-  resolved "https://registry.yarnpkg.com/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.6.tgz#3b6c40a0affe0799a2ce823b440a6cf33571d32b"
-  integrity sha512-cE1jYr2dEg1wBImvXlNtp0xDoS79rfEdGozQVgliDZj1uERH4k+rmEMTudP9b4VQ8O6nRb5gPqft0QzEQGMQgA==
-  dependencies:
-    "@types/lodash" "*"
-
-"@types/lodash.difference@^4.5.6":
-  version "4.5.6"
-  resolved "https://registry.yarnpkg.com/@types/lodash.difference/-/lodash.difference-4.5.6.tgz#41ec5c4e684eeacf543848a9a1b2a4856ccf9853"
-  integrity sha512-wXH53r+uoUCrKhmh7S5Gf6zo3vpsx/zH2R4pvkmDlmopmMTCROAUXDpPMXATGCWkCjE6ik3VZzZUxBgMjZho9Q==
-  dependencies:
-    "@types/lodash" "*"
-
-"@types/lodash.differencewith@^4.5.6":
-  version "4.5.6"
-  resolved "https://registry.yarnpkg.com/@types/lodash.differencewith/-/lodash.differencewith-4.5.6.tgz#7141da68fdcff7785c20a68748b9b071d19b01a9"
-  integrity sha512-SSzBzUdIsVV5bLMP4W5JYlkP4oClh9lCb2Tx4MJHKNDCnbiD+q8xJ+UkSA+W79hDiyuf8m4VvNuXQJgr8eAMAw==
-  dependencies:
-    "@types/lodash" "*"
-
-"@types/lodash.flattendepth@^4.7.6":
-  version "4.7.6"
-  resolved "https://registry.yarnpkg.com/@types/lodash.flattendepth/-/lodash.flattendepth-4.7.6.tgz#e51d3912d21c1f05f82f3df3d893b408b4f9dafc"
-  integrity sha512-CbIW/eH/tlziD/5RtZ13BJk13wkHOUFkcY+/saMyApIBZVcYdC1457XZ29E1MshXNbkGlFHV2sgB0NETI54+3Q==
-  dependencies:
-    "@types/lodash" "*"
-
-"@types/lodash.intersection@^4.4.6":
-  version "4.4.6"
-  resolved "https://registry.yarnpkg.com/@types/lodash.intersection/-/lodash.intersection-4.4.6.tgz#0fb241badf6edbb2a7d194a70c50e950e2486e68"
-  integrity sha512-6ewsKax7+HgT+7mEhzXT6tIyIHc/mjCwZJnarvLbCrtW21qmDQHWbaJj4Ht4DQDBmMdnvZe8APuVlsMpZ5E5mQ==
-  dependencies:
-    "@types/lodash" "*"
-
-"@types/lodash.isequal@^4.5.5":
-  version "4.5.5"
-  resolved "https://registry.yarnpkg.com/@types/lodash.isequal/-/lodash.isequal-4.5.5.tgz#4fed1b1b00bef79e305de0352d797e9bb816c8ff"
-  integrity sha512-4IKbinG7MGP131wRfceK6W4E/Qt3qssEFLF30LnJbjYiSfHGGRU/Io8YxXrZX109ir+iDETC8hw8QsDijukUVg==
-  dependencies:
-    "@types/lodash" "*"
-
-"@types/lodash.isequalwith@^4.4.6":
-  version "4.4.6"
-  resolved "https://registry.yarnpkg.com/@types/lodash.isequalwith/-/lodash.isequalwith-4.4.6.tgz#8c5dee2b2fdc05cfa79a3a77cd40cc8909ef79c9"
-  integrity sha512-55fjBOrhse+SLkqGlvUq1yQ/sDvsi93+ngLIG22DPEoeL4c/d1rtWMMK55pP4nKOjkSWv8ks1q0HaXXCgPr81w==
-  dependencies:
-    "@types/lodash" "*"
-
-"@types/lodash.merge@^4.6.6":
-  version "4.6.6"
-  resolved "https://registry.yarnpkg.com/@types/lodash.merge/-/lodash.merge-4.6.6.tgz#b84b403c1d31bc42d51772d1cd5557fa008cd3d6"
-  integrity sha512-IB90krzMf7YpfgP3u/EvZEdXVvm4e3gJbUvh5ieuI+o+XqiNEt6fCzqNRaiLlPVScLI59RxIGZMQ3+Ko/DJ8vQ==
-  dependencies:
-    "@types/lodash" "*"
-
-"@types/lodash.mergewith@^4.6.6":
-  version "4.6.6"
-  resolved "https://registry.yarnpkg.com/@types/lodash.mergewith/-/lodash.mergewith-4.6.6.tgz#c4698f5b214a433ff35cb2c75ee6ec7f99d79f10"
-  integrity sha512-RY/8IaVENjG19rxTZu9Nukqh0W2UrYgmBj5sdns4hWRZaV8PqR7wIKHFKzvOTjo4zVRV7sVI+yFhAJql12Kfqg==
+"@types/lodash-es@^4.17.6":
+  version "4.17.6"
+  resolved "https://registry.yarnpkg.com/@types/lodash-es/-/lodash-es-4.17.6.tgz#c2ed4c8320ffa6f11b43eb89e9eaeec65966a0a0"
+  integrity sha512-R+zTeVUKDdfoRxpAryaQNRKk3105Rrgx2CFRClIgRGaqDTdjsm8h6IYA8ir584W3ePzkZfst5xIgDwYrlh9HLg==
   dependencies:
     "@types/lodash" "*"
 
@@ -12598,6 +12542,11 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
+lodash-es@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
+  integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
+
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
@@ -12648,16 +12597,6 @@ lodash.defaults@^4.0.1:
   resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
   integrity sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=
 
-lodash.difference@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.difference/-/lodash.difference-4.5.0.tgz#9ccb4e505d486b91651345772885a2df27fd017c"
-  integrity sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw=
-
-lodash.differencewith@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.differencewith/-/lodash.differencewith-4.5.0.tgz#bafafbc918b55154e179176a00bb0aefaac854b7"
-  integrity sha1-uvr7yRi1UVTheRdqALsK76rIVLc=
-
 lodash.filter@^4.4.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.filter/-/lodash.filter-4.6.0.tgz#668b1d4981603ae1cc5a6fa760143e480b4c4ace"
@@ -12677,11 +12616,6 @@ lodash.flatten@^4.2.0, lodash.flatten@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f"
   integrity sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=
-
-lodash.flattendepth@^4.7.0:
-  version "4.7.0"
-  resolved "https://registry.yarnpkg.com/lodash.flattendepth/-/lodash.flattendepth-4.7.0.tgz#b4d2d14fc7d9c53deb96642eb616fff22a60932f"
-  integrity sha1-tNLRT8fZxT3rlmQuthb/8ipgky8=
 
 lodash.flow@^3.3.0:
   version "3.5.0"
@@ -12713,11 +12647,6 @@ lodash.has@^4.5.2:
   resolved "https://registry.yarnpkg.com/lodash.has/-/lodash.has-4.5.2.tgz#d19f4dc1095058cccbe2b0cdf4ee0fe4aa37c862"
   integrity sha1-0Z9NwQlQWMzL4rDN9O4P5Ko3yGI=
 
-lodash.intersection@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/lodash.intersection/-/lodash.intersection-4.4.0.tgz#0a11ba631d0e95c23c7f2f4cbb9a692ed178e705"
-  integrity sha1-ChG6Yx0OlcI8fy9Mu5ppLtF45wU=
-
 lodash.invokemap@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.invokemap/-/lodash.invokemap-4.6.0.tgz#1748cda5d8b0ef8369c4eb3ec54c21feba1f2d62"
@@ -12732,11 +12661,6 @@ lodash.isequal@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
   integrity sha1-QVxEePK8wwEgwizhDtMib30+GOA=
-
-lodash.isequalwith@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/lodash.isequalwith/-/lodash.isequalwith-4.4.0.tgz#266726ddd528f854f21f4ea98a065606e0fbc6b0"
-  integrity sha1-Jmcm3dUo+FTyH06pigZWBuD7xrA=
 
 lodash.isfunction@^3.0.9:
   version "3.0.9"
@@ -12788,15 +12712,10 @@ lodash.memoize@^4.1.2:
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
 
-lodash.merge@^4.4.0, lodash.merge@^4.6.2:
+lodash.merge@^4.4.0:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
-
-lodash.mergewith@^4.6.2:
-  version "4.6.2"
-  resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz#617121f89ac55f59047c7aec1ccd6654c6590f55"
-  integrity sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==
 
 lodash.padstart@^4.6.1:
   version "4.6.1"


### PR DESCRIPTION
Using es-first modules helps when it comes to being more compatible with browsers and supporting _The Future Way™️_.

Fixes #169 

## CHANGELOG
### `graphql-mocks`
```markdown changelog(graphql-mocks)
* (fix) Replace individual `lodash.*` packages with singular `lodash-es`
```

### `graphql-paper`
```markdown changelog(graphql-paper)
* (fix) Replace individual `lodash.*` packages with singular `lodash-es`
```

### `@graphql-mocks/mirage`
```markdown changelog(@graphql-mocks/mirage)
* (fix) Replace individual `lodash.*` packages with singular `lodash-es`
```