### PR TITLE
Migrate from lodash to ramda

### DIFF
--- a/packages/cli/test/commands/serve.test.ts
+++ b/packages/cli/test/commands/serve.test.ts
@@ -7,10 +7,12 @@ import axios from 'axios';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const express = require('express');
 
-describe('serve', () => {
+describe('serve', function () {
   let server: any = null;
   let listenSpy: any = null;
   let axiosPostSpy: any = null;
+
+  this.timeout(10000);
 
   beforeEach(function spyOnExpress() {
     Serve.express = (() => {

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -53,7 +53,7 @@
     "core-js": "^3.6.5",
     "event-target-polyfill": "^0.0.3",
     "globby": "^11.0.1",
-    "lodash.uniq": "^4.5.0",
+    "ramda": "^0.28.0",
     "mocha": "^8.0.1",
     "prettier": "^2.0.5",
     "react-syntax-highlighter": "^15.4.3",

--- a/packages/graphql-mocks/package.json
+++ b/packages/graphql-mocks/package.json
@@ -25,15 +25,7 @@
     "node": ">= 12.0.0"
   },
   "dependencies": {
-    "lodash.clonedeep": "^4.5.0",
-    "lodash.difference": "^4.5.0",
-    "lodash.differencewith": "^4.5.0",
-    "lodash.flattendepth": "^4.7.0",
-    "lodash.intersection": "^4.4.0",
-    "lodash.isequal": "^4.5.0",
-    "lodash.isequalwith": "^4.4.0",
-    "lodash.merge": "^4.6.2",
-    "lodash.mergewith": "^4.6.2"
+    "ramda": "^0.28.0"
   },
   "peerDependencies": {
     "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
@@ -42,15 +34,7 @@
     "sinon": "^9.0.0"
   },
   "devDependencies": {
-    "@types/lodash.clonedeep": "^4.5.6",
-    "@types/lodash.difference": "^4.5.6",
-    "@types/lodash.differencewith": "^4.5.6",
-    "@types/lodash.flattendepth": "^4.7.6",
-    "@types/lodash.intersection": "^4.4.6",
-    "@types/lodash.isequal": "^4.5.5",
-    "@types/lodash.isequalwith": "^4.4.6",
-    "@types/lodash.merge": "^4.6.6",
-    "@types/lodash.mergewith": "^4.6.6",
+    "@types/ramda": "^0.28.12",
     "@types/sinon": "^10.0.2",
     "miragejs": "^0.1.40",
     "sinon": "^9.0.0"

--- a/packages/graphql-mocks/src/highlight/highlight.ts
+++ b/packages/graphql-mocks/src/highlight/highlight.ts
@@ -1,5 +1,5 @@
 import { GraphQLSchema } from 'graphql';
-import clone from 'lodash.clonedeep';
+import { clone } from 'ramda';
 import { include } from './operation/include';
 import { exclude } from './operation/exclude';
 import { filter } from './operation/filter';

--- a/packages/graphql-mocks/src/highlight/highlighter/resolves-to.ts
+++ b/packages/graphql-mocks/src/highlight/highlighter/resolves-to.ts
@@ -39,8 +39,6 @@ function getResolvableAST(resolveString: string): NamedTypeNode | undefined {
 
 type WrapperTypeNode = ListTypeNode | NonNullTypeNode;
 function compareTypeNodes(a: TypeNode, b: TypeNode): boolean {
-  // console.log(a, b);
-
   const aHasType = a && 'type' in a;
   const bHasType = b && 'type' in b;
 

--- a/packages/graphql-mocks/src/highlight/highlighter/resolves-to.ts
+++ b/packages/graphql-mocks/src/highlight/highlighter/resolves-to.ts
@@ -6,10 +6,13 @@ import {
   FieldDefinitionNode,
   NamedTypeNode,
   GraphQLObjectType,
+  TypeNode,
+  ListTypeNode,
+  NonNullTypeNode,
 } from 'graphql';
 import { HighlighterFactory, Highlighter, FieldReference } from '../types';
-import isEqualWith from 'lodash.isequalwith';
 import { HIGHLIGHT_ALL } from './constants';
+import { evolve, equals, omit } from 'ramda';
 
 function concat<T>(a: T[], b: T[]): T[] {
   return ([] as T[]).concat(a, b);
@@ -33,6 +36,24 @@ function getResolvableAST(resolveString: string): NamedTypeNode | undefined {
   const fieldNode: FieldDefinitionNode = objectNode?.fields?.[0] as FieldDefinitionNode;
   return fieldNode.type as NamedTypeNode;
 }
+
+type WrapperTypeNode = ListTypeNode | NonNullTypeNode;
+function compareTypeNodes(a: TypeNode, b: TypeNode): boolean {
+  // console.log(a, b);
+
+  const aHasType = a && 'type' in a;
+  const bHasType = b && 'type' in b;
+
+  if (aHasType && bHasType && a.kind === b.kind) {
+    return compareTypeNodes((a as WrapperTypeNode).type, (b as WrapperTypeNode).type);
+  } else if (typeof a === 'object' && typeof b === 'object') {
+    const removeLocsFromNamedTypeNode = evolve({ loc: () => undefined, name: omit(['loc']) });
+    return equals(removeLocsFromNamedTypeNode(a as NamedTypeNode), removeLocsFromNamedTypeNode(b as NamedTypeNode));
+  } else {
+    return false;
+  }
+}
+
 export class ResolvesToHighlighter implements Highlighter {
   targets: string[];
 
@@ -63,15 +84,11 @@ export class ResolvesToHighlighter implements Highlighter {
       .filter(isObjectType)
       .map((type: GraphQLObjectType) => {
         const fields = Object.values(type.getFields());
-
         const fieldReferences = fields.reduce((fieldReferences: FieldReference[], field) => {
           const fieldReturnAST = field.astNode?.type as NamedTypeNode;
-          const equalAST = isEqualWith([fieldReturnAST], [targetAST], function (_left, _right, key) {
-            if (key === 'loc') return true;
-            return undefined;
-          });
+          const typeNodesEqual = compareTypeNodes(targetAST, fieldReturnAST);
 
-          if (equalAST) {
+          if (typeNodesEqual) {
             fieldReferences.push([type.name, field.name]);
           }
 

--- a/packages/graphql-mocks/src/highlight/operation/exclude.ts
+++ b/packages/graphql-mocks/src/highlight/operation/exclude.ts
@@ -1,7 +1,7 @@
-import differenceWith from 'lodash.differencewith';
+import { differenceWith } from 'ramda';
 import { Reference } from '../types';
 import { isEqual } from '../utils/is-equal';
 
 export function exclude(source: Reference[], update: Reference[]): Reference[] {
-  return differenceWith(source, update, isEqual);
+  return differenceWith(isEqual)(source, update);
 }

--- a/packages/graphql-mocks/src/highlight/utils/unique.ts
+++ b/packages/graphql-mocks/src/highlight/utils/unique.ts
@@ -1,11 +1,11 @@
 import { Reference } from '../types';
-import isEqual from 'lodash.isequal';
+import { equals } from 'ramda';
 
 export function unique(fieldReferences: Reference[]): Reference[] {
   const uniques: Reference[] = [];
 
   fieldReferences.forEach((reference: Reference) => {
-    const match = uniques.find((uniqueReference) => isEqual(reference, uniqueReference));
+    const match = uniques.find((uniqueReference) => equals(reference, uniqueReference));
     if (!match) uniques.push(reference);
   });
 

--- a/packages/graphql-mocks/src/pack/pack.ts
+++ b/packages/graphql-mocks/src/pack/pack.ts
@@ -1,4 +1,4 @@
-import cloneDeep from 'lodash.clonedeep';
+import { clone } from 'ramda';
 import { embed } from '../resolver-map/embed';
 import { embedPackOptionsWrapper } from './utils';
 import { PackOptions, Packer, PackState } from './types';
@@ -12,7 +12,7 @@ export const pack: Packer = async function pack(
   middlewares = [...middlewares, embed({ wrappers: [embedPackOptionsWrapper] })];
 
   // make an initial copy
-  let wrappedMap = cloneDeep(initialResolversMap);
+  let wrappedMap = clone(initialResolversMap);
   packOptions = normalizePackOptions(packOptions);
 
   for (const middleware of middlewares) {

--- a/packages/graphql-mocks/src/resolver-map/layer.ts
+++ b/packages/graphql-mocks/src/resolver-map/layer.ts
@@ -1,7 +1,7 @@
 import { ResolverMapMiddleware, ResolverMap, ObjectField } from '../types';
 import { ReplaceableResolverOption, WrappableOption } from './types';
 import { pack } from '../pack';
-import merge from 'lodash.merge';
+import { mergeDeepRight } from 'ramda';
 import { hi, fromResolverMap } from '../highlight';
 import { GraphQLSchema, GraphQLObjectType, GraphQLAbstractType } from 'graphql';
 import { walk } from '../highlight/utils';
@@ -20,7 +20,7 @@ export function layer(partials: ResolverMap[], options?: LayerOptions): Resolver
   };
 
   const layerMiddlewares = partials.map((resolverMap) => (previous: ResolverMap): ResolverMap => {
-    return merge({}, previous, resolverMap);
+    return mergeDeepRight(previous, resolverMap);
   });
 
   const middleware: ResolverMapMiddleware = async function layerMiddleware(resolverMap, packOptions) {

--- a/packages/mirage/package.json
+++ b/packages/mirage/package.json
@@ -25,10 +25,10 @@
     "node": ">= 12.0.0"
   },
   "dependencies": {
-    "lodash.intersection": "^4.4.0"
+    "ramda": "^0.28.0"
   },
   "devDependencies": {
-    "@types/lodash.intersection": "^4.4.6",
+    "@types/ramda": "^0.28.12",
     "@types/sinon": "^10.0.2",
     "graphql-mocks": "^0.8.3",
     "miragejs": "^0.1.40",

--- a/packages/mirage/src/utils.ts
+++ b/packages/mirage/src/utils.ts
@@ -1,4 +1,4 @@
-import intersection from 'lodash.intersection';
+import { intersection } from 'ramda';
 import {
   GraphQLEnumType,
   GraphQLInputObjectType,

--- a/packages/paper/package.json
+++ b/packages/paper/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "immer": "^9.0.6",
     "just-diff": "^3.1.1",
-    "lodash.merge": "^4.6.2",
+    "ramda": "^0.28.0",
     "short-unique-id": "^4.3.3"
   },
   "peerDependencies": {
@@ -37,6 +37,7 @@
     "event-target-polyfill": "^0.0.3"
   },
   "devDependencies": {
-    "graphql-mocks": "^0.8.3"
+    "graphql-mocks": "^0.8.3",
+    "@types/ramda": "^0.28.12"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4791,69 +4791,6 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.6.tgz#f4c7ec43e81b319a9815115031709f26987891f0"
   integrity sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==
 
-"@types/lodash.clonedeep@^4.5.6":
-  version "4.5.6"
-  resolved "https://registry.yarnpkg.com/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.6.tgz#3b6c40a0affe0799a2ce823b440a6cf33571d32b"
-  integrity sha512-cE1jYr2dEg1wBImvXlNtp0xDoS79rfEdGozQVgliDZj1uERH4k+rmEMTudP9b4VQ8O6nRb5gPqft0QzEQGMQgA==
-  dependencies:
-    "@types/lodash" "*"
-
-"@types/lodash.difference@^4.5.6":
-  version "4.5.6"
-  resolved "https://registry.yarnpkg.com/@types/lodash.difference/-/lodash.difference-4.5.6.tgz#41ec5c4e684eeacf543848a9a1b2a4856ccf9853"
-  integrity sha512-wXH53r+uoUCrKhmh7S5Gf6zo3vpsx/zH2R4pvkmDlmopmMTCROAUXDpPMXATGCWkCjE6ik3VZzZUxBgMjZho9Q==
-  dependencies:
-    "@types/lodash" "*"
-
-"@types/lodash.differencewith@^4.5.6":
-  version "4.5.6"
-  resolved "https://registry.yarnpkg.com/@types/lodash.differencewith/-/lodash.differencewith-4.5.6.tgz#7141da68fdcff7785c20a68748b9b071d19b01a9"
-  integrity sha512-SSzBzUdIsVV5bLMP4W5JYlkP4oClh9lCb2Tx4MJHKNDCnbiD+q8xJ+UkSA+W79hDiyuf8m4VvNuXQJgr8eAMAw==
-  dependencies:
-    "@types/lodash" "*"
-
-"@types/lodash.flattendepth@^4.7.6":
-  version "4.7.6"
-  resolved "https://registry.yarnpkg.com/@types/lodash.flattendepth/-/lodash.flattendepth-4.7.6.tgz#e51d3912d21c1f05f82f3df3d893b408b4f9dafc"
-  integrity sha512-CbIW/eH/tlziD/5RtZ13BJk13wkHOUFkcY+/saMyApIBZVcYdC1457XZ29E1MshXNbkGlFHV2sgB0NETI54+3Q==
-  dependencies:
-    "@types/lodash" "*"
-
-"@types/lodash.intersection@^4.4.6":
-  version "4.4.6"
-  resolved "https://registry.yarnpkg.com/@types/lodash.intersection/-/lodash.intersection-4.4.6.tgz#0fb241badf6edbb2a7d194a70c50e950e2486e68"
-  integrity sha512-6ewsKax7+HgT+7mEhzXT6tIyIHc/mjCwZJnarvLbCrtW21qmDQHWbaJj4Ht4DQDBmMdnvZe8APuVlsMpZ5E5mQ==
-  dependencies:
-    "@types/lodash" "*"
-
-"@types/lodash.isequal@^4.5.5":
-  version "4.5.5"
-  resolved "https://registry.yarnpkg.com/@types/lodash.isequal/-/lodash.isequal-4.5.5.tgz#4fed1b1b00bef79e305de0352d797e9bb816c8ff"
-  integrity sha512-4IKbinG7MGP131wRfceK6W4E/Qt3qssEFLF30LnJbjYiSfHGGRU/Io8YxXrZX109ir+iDETC8hw8QsDijukUVg==
-  dependencies:
-    "@types/lodash" "*"
-
-"@types/lodash.isequalwith@^4.4.6":
-  version "4.4.6"
-  resolved "https://registry.yarnpkg.com/@types/lodash.isequalwith/-/lodash.isequalwith-4.4.6.tgz#8c5dee2b2fdc05cfa79a3a77cd40cc8909ef79c9"
-  integrity sha512-55fjBOrhse+SLkqGlvUq1yQ/sDvsi93+ngLIG22DPEoeL4c/d1rtWMMK55pP4nKOjkSWv8ks1q0HaXXCgPr81w==
-  dependencies:
-    "@types/lodash" "*"
-
-"@types/lodash.merge@^4.6.6":
-  version "4.6.6"
-  resolved "https://registry.yarnpkg.com/@types/lodash.merge/-/lodash.merge-4.6.6.tgz#b84b403c1d31bc42d51772d1cd5557fa008cd3d6"
-  integrity sha512-IB90krzMf7YpfgP3u/EvZEdXVvm4e3gJbUvh5ieuI+o+XqiNEt6fCzqNRaiLlPVScLI59RxIGZMQ3+Ko/DJ8vQ==
-  dependencies:
-    "@types/lodash" "*"
-
-"@types/lodash.mergewith@^4.6.6":
-  version "4.6.6"
-  resolved "https://registry.yarnpkg.com/@types/lodash.mergewith/-/lodash.mergewith-4.6.6.tgz#c4698f5b214a433ff35cb2c75ee6ec7f99d79f10"
-  integrity sha512-RY/8IaVENjG19rxTZu9Nukqh0W2UrYgmBj5sdns4hWRZaV8PqR7wIKHFKzvOTjo4zVRV7sVI+yFhAJql12Kfqg==
-  dependencies:
-    "@types/lodash" "*"
-
 "@types/lodash@*":
   version "4.14.182"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.182.tgz#05301a4d5e62963227eaafe0ce04dd77c54ea5c2"
@@ -4970,6 +4907,13 @@
   version "6.9.7"
   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.7.tgz#63bb7d067db107cc1e457c303bc25d511febf6cb"
   integrity sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==
+
+"@types/ramda@^0.28.12":
+  version "0.28.12"
+  resolved "https://registry.yarnpkg.com/@types/ramda/-/ramda-0.28.12.tgz#03a8d2e5d12a4d940cdf9ebf7201d3b98ee8d87f"
+  integrity sha512-01lBa/nWJMmzc7uwvN4pzoePRWMURV1uRpchCpomAFW1MvMSyOtHjj8/WpaCFrrBQ8Mvpasm/CK3YpcWbVcZ3g==
+  dependencies:
+    ts-toolbelt "^6.15.1"
 
 "@types/range-parser@*":
   version "1.2.4"
@@ -12648,16 +12592,6 @@ lodash.defaults@^4.0.1:
   resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
   integrity sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=
 
-lodash.difference@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.difference/-/lodash.difference-4.5.0.tgz#9ccb4e505d486b91651345772885a2df27fd017c"
-  integrity sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw=
-
-lodash.differencewith@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.differencewith/-/lodash.differencewith-4.5.0.tgz#bafafbc918b55154e179176a00bb0aefaac854b7"
-  integrity sha1-uvr7yRi1UVTheRdqALsK76rIVLc=
-
 lodash.filter@^4.4.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.filter/-/lodash.filter-4.6.0.tgz#668b1d4981603ae1cc5a6fa760143e480b4c4ace"
@@ -12677,11 +12611,6 @@ lodash.flatten@^4.2.0, lodash.flatten@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f"
   integrity sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=
-
-lodash.flattendepth@^4.7.0:
-  version "4.7.0"
-  resolved "https://registry.yarnpkg.com/lodash.flattendepth/-/lodash.flattendepth-4.7.0.tgz#b4d2d14fc7d9c53deb96642eb616fff22a60932f"
-  integrity sha1-tNLRT8fZxT3rlmQuthb/8ipgky8=
 
 lodash.flow@^3.3.0:
   version "3.5.0"
@@ -12713,11 +12642,6 @@ lodash.has@^4.5.2:
   resolved "https://registry.yarnpkg.com/lodash.has/-/lodash.has-4.5.2.tgz#d19f4dc1095058cccbe2b0cdf4ee0fe4aa37c862"
   integrity sha1-0Z9NwQlQWMzL4rDN9O4P5Ko3yGI=
 
-lodash.intersection@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/lodash.intersection/-/lodash.intersection-4.4.0.tgz#0a11ba631d0e95c23c7f2f4cbb9a692ed178e705"
-  integrity sha1-ChG6Yx0OlcI8fy9Mu5ppLtF45wU=
-
 lodash.invokemap@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.invokemap/-/lodash.invokemap-4.6.0.tgz#1748cda5d8b0ef8369c4eb3ec54c21feba1f2d62"
@@ -12732,11 +12656,6 @@ lodash.isequal@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
   integrity sha1-QVxEePK8wwEgwizhDtMib30+GOA=
-
-lodash.isequalwith@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/lodash.isequalwith/-/lodash.isequalwith-4.4.0.tgz#266726ddd528f854f21f4ea98a065606e0fbc6b0"
-  integrity sha1-Jmcm3dUo+FTyH06pigZWBuD7xrA=
 
 lodash.isfunction@^3.0.9:
   version "3.0.9"
@@ -12788,15 +12707,10 @@ lodash.memoize@^4.1.2:
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
 
-lodash.merge@^4.4.0, lodash.merge@^4.6.2:
+lodash.merge@^4.4.0:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
-
-lodash.mergewith@^4.6.2:
-  version "4.6.2"
-  resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz#617121f89ac55f59047c7aec1ccd6654c6590f55"
-  integrity sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==
 
 lodash.padstart@^4.6.1:
   version "4.6.1"
@@ -16309,6 +16223,11 @@ ramda@^0.27.1:
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.27.1.tgz#66fc2df3ef873874ffc2da6aa8984658abacf5c9"
   integrity sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw==
 
+ramda@^0.28.0:
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.28.0.tgz#acd785690100337e8b063cab3470019be427cc97"
+  integrity sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA==
+
 randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5, randombytes@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
@@ -18913,6 +18832,11 @@ ts-pnp@^1.1.6:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.2.0.tgz#a500ad084b0798f1c3071af391e65912c86bca92"
   integrity sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==
+
+ts-toolbelt@^6.15.1:
+  version "6.15.5"
+  resolved "https://registry.yarnpkg.com/ts-toolbelt/-/ts-toolbelt-6.15.5.tgz#cb3b43ed725cb63644782c64fbcad7d8f28c0a83"
+  integrity sha512-FZIXf1ksVyLcfr7M317jbB67XFJhOO1YqdTcuGaq9q5jLUoTikukZ+98TPjKiP2jC5CgmYdWWYs0s2nLSU0/1A==
 
 tslib@^1.10.0, tslib@^1.9.3:
   version "1.14.1"


### PR DESCRIPTION
Using es-first modules helps when it comes to being more compatible with browsers and supporting _The Future Way™️_.

Using `ramda` instead of `lodash-es` because `ramda` supports esmodules and commonjs modules from a single package (specifically important for node which was throwing errors about the `type="module"` in `lodash-es`).

Fixes #169 
Supersedes #171 

## CHANGELOG
### `graphql-mocks`
```markdown changelog(graphql-mocks)
* (fix) Replace individual `lodash.*` packages with singular `ramda`
```

### `graphql-paper`
```markdown changelog(graphql-paper)
* (fix) Replace individual `lodash.*` packages with singular `ramda`
```

### `@graphql-mocks/mirage`
```markdown changelog(@graphql-mocks/mirage)
* (fix) Replace individual `lodash.*` packages with singular `ramda`
```