### PR TITLE
Add latency wrapper

### DIFF
--- a/packages/docs/docs/resolver/available-wrappers.md
+++ b/packages/docs/docs/resolver/available-wrappers.md
@@ -7,6 +7,48 @@ The following is a list of Resolver Wrappers. If you create one that could be us
 Issue or Pull Request so that it can be added. Also, learn how to [create your own](/docs/resolver/creating-wrappers) and
 [apply Resolver Wrappers](/docs/resolver/applying-wrappers) to a Resolver Map.
 
+## Latency Wrapper
+
+Package: `graphql-mocks`
+
+```js
+import { latencyWrapper } from 'graphql-mocks/wrapper';
+```
+
+Use the `latencyWrapper` to provide more realistic latency to resolvers. This can be useful to simulate resolvers that might take a bit longer.
+
+This wrapper can take either a number (in milliseconds), or an array of a lower bound and upper bound and a number will be chosen at random between these.
+
+```js
+// will wait 200 milliseconds
+latencyWrapper(200)
+
+// will wait between 200 and 800 milliseconds
+latencyWrapper([200, 800])
+```
+
+This is what the latency wrapper would like applied to resolvers using the `embed` middleware, applying a delay of 200 milliseconds to all top-level Query resolvers.
+```js
+// specified in milliseconds
+const latencyDelay = 200;
+
+// create a Resolver Map Middleware that applies the
+// latency wrapper to all top-level Query resolvers
+const latencyMiddleware = embed({
+  wrappers: [latencyWrapper(latencyDelay)],
+  h: (h) => h.include(field(['Query', '*']))
+});
+
+const handler = new GraphQLHandler({
+  resolverMap,
+  middlewares: [latencyMiddleware],
+  dependencies: { graphqlSchema },
+});
+
+// this will take at least 200 milliseconds
+await handler.query(`{ hello }`);
+```
+
 ## Log Wrapper
 
 Package: `graphql-mocks`

--- a/packages/graphql-mocks/src/wrapper/index.ts
+++ b/packages/graphql-mocks/src/wrapper/index.ts
@@ -1,2 +1,3 @@
 export { logWrapper } from './log';
 export { stashStateWrapper, stashFor } from './stash-state';
+export { latencyWrapper } from './latency';

--- a/packages/graphql-mocks/src/wrapper/latency.ts
+++ b/packages/graphql-mocks/src/wrapper/latency.ts
@@ -1,0 +1,29 @@
+import { createWrapper, WrapperFor } from '../resolver';
+import { NamedWrapper } from '../resolver/types';
+
+type LatencyInMs = number;
+type Latency = LatencyInMs | [LatencyInMs, LatencyInMs];
+
+function getRandomInt(min: number, max: number) {
+  min = Math.ceil(min);
+  max = Math.floor(max);
+  return Math.round(Math.random() * (max - min) + min);
+}
+
+async function wait(ms: number) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+export function latencyWrapper(latency: Latency = 0): NamedWrapper<'ANY'> {
+  const finalLatency = Array.isArray(latency) ? getRandomInt(latency[0], latency[1]) : latency;
+
+  return createWrapper('latency-wrapper', WrapperFor.ANY, function (originalResolver, _options) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return async function (...args: [any, any, any, any]) {
+      await wait(finalLatency);
+      return originalResolver(...args);
+    };
+  });
+}

--- a/packages/graphql-mocks/test/unit/wrapper/latency.test.ts
+++ b/packages/graphql-mocks/test/unit/wrapper/latency.test.ts
@@ -1,0 +1,71 @@
+import { latencyWrapper } from '../../../src/wrapper';
+import { SinonSpy, spy } from 'sinon';
+import { expect } from 'chai';
+
+class Timer {
+  startTime: number | null = null;
+  stopTime: number | null = null;
+
+  start() {
+    if (this.startTime) {
+      throw new Error('start already called');
+    }
+
+    this.startTime = Date.now();
+  }
+
+  stop() {
+    if (this.stopTime) {
+      throw new Error('stop already called');
+    }
+
+    this.stopTime = Date.now();
+  }
+
+  get elapsed() {
+    if (!this.startTime) {
+      throw new Error('start has not been called');
+    }
+
+    if (!this.stopTime) {
+      throw new Error('stop has not been called');
+    }
+
+    return Math.floor(this.stopTime - this.startTime);
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const anyArg: any = {};
+
+describe('wrapper/latency', function () {
+  let timer: Timer;
+  let resolverSpy: SinonSpy;
+
+  beforeEach(function () {
+    timer = new Timer();
+    resolverSpy = spy();
+  });
+
+  it('delays for a specific amount of milliseconds', async function () {
+    const latency = 1000;
+    const wrappedResolver = await latencyWrapper(latency).wrap(resolverSpy, {} as any);
+    timer.start();
+    await wrappedResolver(anyArg, anyArg, anyArg, anyArg);
+    timer.stop();
+    expect(timer.elapsed).to.be.greaterThan(latency - 10);
+    expect(timer.elapsed).to.be.lessThan(latency + 10);
+    expect(resolverSpy.calledWithExactly(anyArg, anyArg, anyArg, anyArg)).to.be.true;
+  });
+
+  it('delays for a range of milliseconds', async function () {
+    const latency: [number, number] = [1000, 1500];
+    const wrappedResolver = await latencyWrapper(latency).wrap(resolverSpy, {} as any);
+    timer.start();
+    await wrappedResolver(anyArg, anyArg, anyArg, anyArg);
+    timer.stop();
+    expect(timer.elapsed).to.be.greaterThan(latency[0] - 10);
+    expect(timer.elapsed).to.be.lessThan(latency[1] + 10);
+    expect(resolverSpy.calledWithExactly(anyArg, anyArg, anyArg, anyArg)).to.be.true;
+  });
+});


### PR DESCRIPTION
As in *The Real World :tm:* some resolvers may take longer than others due to their complexity or some async task that might be performed within them. This pull request adds a latency wrapper to be able to delay resolvers by some latency in milliseconds (either a specific number `1000` or a random number within a range `[1000, 1500]`).

Closes #64.

- [X] Implement latency wrapper
- [X] Tests
- [x] Write documentation

## CHANGELOG
### `graphql-mocks`
```markdown changelog(graphql-mocks)
* (feature) Added latency wrapper for delaying resolvers with specified latency
```
