### PR TITLE
Make browser-acceptance-tests a private package

### DIFF
--- a/packages/browser-acceptance-tests/package.json
+++ b/packages/browser-acceptance-tests/package.json
@@ -3,6 +3,7 @@
   "version": "0.2.0",
   "main": "index.js",
   "license": "MIT",
+  "private": true,
   "scripts": {
     "start": "SKIP_PREFLIGHT_CHECK=true react-scripts start",
     "build": "echo \"No build required for browser-acceptance-tests, only for testing\"",


### PR DESCRIPTION
After going to do a publish of packages with lerna, it was clear that `browser-acceptance-tests` internal package for testing browser network adapters was missing a `private: true` flag 🙈 