### PR TITLE
feat: add `clear` method to graphql-paper

### DIFF
--- a/packages/paper/src/paper.ts
+++ b/packages/paper/src/paper.ts
@@ -74,6 +74,10 @@ export class Paper<UserOperations extends OperationMap = OperationMap> {
     return findDocument(this.data, documentOrKey);
   }
 
+  truncate(): void {
+    this.current = createDocumentStore(this.sourceGraphQLSchema);
+  }
+
   private validate(_store?: DocumentStore): void {
     const store = _store ?? this.current;
 

--- a/packages/paper/src/paper.ts
+++ b/packages/paper/src/paper.ts
@@ -74,7 +74,7 @@ export class Paper<UserOperations extends OperationMap = OperationMap> {
     return findDocument(this.data, documentOrKey);
   }
 
-  truncate(): void {
+  clear(): void {
     this.current = createDocumentStore(this.sourceGraphQLSchema);
     this.history = [];
   }

--- a/packages/paper/src/paper.ts
+++ b/packages/paper/src/paper.ts
@@ -76,6 +76,7 @@ export class Paper<UserOperations extends OperationMap = OperationMap> {
 
   truncate(): void {
     this.current = createDocumentStore(this.sourceGraphQLSchema);
+    this.history = [];
   }
 
   private validate(_store?: DocumentStore): void {

--- a/packages/paper/test/unit/paper.test.ts
+++ b/packages/paper/test/unit/paper.test.ts
@@ -129,3 +129,26 @@ describe('data', () => {
     expect(paper.data.Person[0].bestFriend.bestFriend.name).to.equal('Ronald');
   });
 });
+
+describe('truncate', () => {
+  it('should purge all documents', async () => {
+    const paper = new Paper(graphqlSchema);
+
+    await paper.mutate(({ create }) => {
+      const ronald = create('Person', {
+        name: 'Ronald',
+      });
+
+      const jessica = create('Person', {
+        name: 'Jessica',
+      });
+
+      ronald.bestFriend = jessica;
+      jessica.bestFriend = ronald;
+    });
+
+    expect(paper.data.Person).to.have.length(2);
+    paper.truncate();
+    expect(paper.data.Person).to.have.length(0);
+  });
+});

--- a/packages/paper/test/unit/paper.test.ts
+++ b/packages/paper/test/unit/paper.test.ts
@@ -130,7 +130,7 @@ describe('data', () => {
   });
 });
 
-describe('truncate', () => {
+describe('clear', () => {
   it('should purge all documents', async () => {
     const paper = new Paper(graphqlSchema);
 
@@ -148,7 +148,7 @@ describe('truncate', () => {
     });
 
     expect(paper.data.Person).to.have.length(2);
-    paper.truncate();
+    paper.clear();
     expect(paper.data.Person).to.have.length(0);
   });
 });


### PR DESCRIPTION
## Description 

This PR adds a `clear` method to the `Paper` to purge all stored documents. This functionality is useful for resetting the store after each test to prevent cross-test data dependencies.

related issue: #206 

## CHANGELOG

### `graphql-paper`
```markdown changelog(graphql-paper)
* (feature) Add `clear` method for purging all documents and resetting history
```
