### PR TITLE
Publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,3 +148,11 @@
 #### Update READMEs and package documentation ([#170](https://github.com/graphql-mocks/graphql-mocks/pull/170))
 
 * (feature) Added package README
+
+## @graphql-mocks/network-cypress
+
+### @graphql-mocks/network-cypress@0.1.0
+
+#### feat: add `@graphql-mocks/network-cypress` package ([#196](https://github.com/graphql-mocks/graphql-mocks/pull/196))
+
+* (feature) Introducing `@graphql-mocks/network-cypress`, a new network handler for cypress

--- a/packages/browser-acceptance-tests/package.json
+++ b/packages/browser-acceptance-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browser-acceptance-tests",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "main": "index.js",
   "license": "MIT",
   "private": true,

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphql-mocks/docs",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "private": true,
   "scripts": {
     "clean": "docusaurus clear",

--- a/packages/falso/package.json
+++ b/packages/falso/package.json
@@ -33,6 +33,6 @@
   "peerDependencies": {
     "@ngneat/falso": "^5.3.0",
     "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0",
-    "graphql-mocks": "^0.8.4"
+    "graphql-mocks": ">=0.8.4"
   }
 }

--- a/packages/mirage/package.json
+++ b/packages/mirage/package.json
@@ -36,7 +36,7 @@
   },
   "peerDependencies": {
     "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0",
-    "graphql-mocks": "^0.8.4",
+    "graphql-mocks": ">=0.8.4",
     "miragejs": "^0.1.40"
   }
 }

--- a/packages/network-cypress/package.json
+++ b/packages/network-cypress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphql-mocks/network-cypress",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "author": "Mohammad Ataei",
   "description": "Mock using graphql-mocks with cypress",
   "main": "dist/index.js",
@@ -27,12 +27,12 @@
   },
   "devDependencies": {
     "axios": "^0.27.2",
-    "graphql-mocks": "^0.8.4",
     "cypress": "^10.0.3",
+    "graphql-mocks": "^0.8.4",
     "vite": "^2.9.0"
   },
   "peerDependencies": {
-    "graphql-mocks": "0.7.2 || >=0.8.1",
-    "cypress": "^8.0.0 || ^ 9.0.0 || ^10.0.0"
+    "cypress": "^8.0.0 || ^ 9.0.0 || ^10.0.0",
+    "graphql-mocks": "0.7.2 || >=0.8.1"
   }
 }


### PR DESCRIPTION
 - gqlmocks@0.2.0
 - @graphql-mocks/falso@0.4.0
 - graphql-mocks@0.8.4
 - @graphql-mocks/mirage@0.6.0
 - @graphql-mocks/network-cypress@0.1.0
 - @graphql-mocks/network-express@0.1.4
 - @graphql-mocks/network-msw@0.1.4
 - @graphql-mocks/network-nock@0.3.3
 - @graphql-mocks/network-pretender@0.1.0
 - graphql-paper@0.1.6
 - @graphql-mocks/sinon@0.2.3