### PR TITLE
Link up documentation for @graphql-mocks/network-cypress

### DIFF
--- a/packages/docs/docs/network/introducing-network-handlers.md
+++ b/packages/docs/docs/network/introducing-network-handlers.md
@@ -29,6 +29,10 @@ Depending on the situation different network handling will be appropriate for yo
 * `@graphql-mocks/network-pretender`
 * [Documentation](/docs/network/pretender)
 
+### Cypress
+* `@graphql-mocks/network-cypress`
+* [Documentation](/docs/network/cypress)
+
 ## Node Network Handlers
 
 ### Express

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -15,6 +15,7 @@
     "build:api:network-express": "yarn --cwd ../network-express typedoc --readme none --out ../docs/static/api/network-express src/index.ts",
     "build:api:network-msw": "yarn --cwd ../network-msw typedoc --readme none --out ../docs/static/api/network-msw src/index.ts",
     "build:api:network-pretender": "yarn --cwd ../network-pretender typedoc --readme none --out ../docs/static/api/network-pretender src/index.ts",
+    "build:api:network-cypress": "yarn --cwd ../network-cypress typedoc --readme none --out ../docs/static/api/network-cypress src/index.ts",
     "build:api:falso": "yarn --cwd ../falso typedoc --readme none --out ../docs/static/api/falso src/index.ts",
     "build:docs": "CODE_EXAMPLE_ENV=docs docusaurus build",
     "swizzle": "docusaurus swizzle",

--- a/packages/docs/sidebars.js
+++ b/packages/docs/sidebars.js
@@ -35,6 +35,7 @@ module.exports = {
         'network/msw',
         'network/pretender',
         'network/express',
+        'network/cypress',
         'network/nock',
       ],
     },

--- a/packages/docs/src/pages/packages.jsx
+++ b/packages/docs/src/pages/packages.jsx
@@ -54,6 +54,9 @@ function Packages() {
                 <Package directoryName="network-pretender" packageName="@graphql-mocks/network-pretender" />
               </tr>
               <tr>
+                <Package directoryName="network-cypress" packageName="@graphql-mocks/network-cypress" />
+              </tr>
+              <tr>
                 <Package directoryName="network-nock" packageName="@graphql-mocks/network-nock" />
               </tr>
               <tr>


### PR DESCRIPTION
Link up a few things on the documentation site for `@graphql-mocks/network-cypress` so that it's available in the sidebar and in the API and Packages section. Closes #209 