### PR TITLE
Improve cli `serve` command flags

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -17,6 +17,7 @@
     "@oclif/core": "^1",
     "@oclif/plugin-help": "^5",
     "@oclif/plugin-version": "^1.0.4",
+    "@types/cors": "^2.8.12",
     "axios": "^0.23.0",
     "chalk": "^4.1.2",
     "config": "^3.3.6",

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -55,7 +55,7 @@ export default class Serve extends Command {
 
   static examples = [
     `$ gqlmocks serve --schema ../schema.graphql`,
-    `$ gqlmocks serve --schema ../schema.graphql --handler ../handler.ts`,
+    `$ gqlmocks serve --handler ../handler.ts`,
     `$ gqlmocks serve --schema http://s3-bucket/schema.graphql --fake`,
     `$ gqlmocks serve --schema http://graphql-api/ --fake`,
     `$ gqlmocks serve --schema http://graphql-api/ --header "Authorization=Bearer token" --fake`,
@@ -98,7 +98,7 @@ export default class Serve extends Command {
     return loaded;
   }
 
-  async startServer({ handlerPath, schema, port, middlewares }: any) {
+  async startServer({ handlerPath, schemaPath, schemaHeaders, port, middlewares }: any) {
     let handler;
 
     if (handlerPath) {
@@ -107,15 +107,22 @@ export default class Serve extends Command {
       } catch (e) {
         this.error(`Unable to find handler at ${handlerPath}.\n\n${(e as Error).message}`);
       }
-    } else {
+    } else if (schemaPath) {
+      const schema = await createSchemaFromLocation(schemaPath, schemaHeaders);
+
       handler = new GraphQLHandler({
         dependencies: {
           graphqlSchema: schema,
         },
       });
+    } else {
+      this.error(
+        'A graphql schema or handler path is required, specify a schema or handler via a gqlmocks config, or --schema or --handler flag',
+      );
     }
 
-    (handler as any).middlewares = middlewares;
+    (handler as any).middlewares = [...(handler as any).middlewares, ...middlewares];
+
     cli.ux.action.start(`Starting graphql api server on port ${port}`);
     const app = Serve.express();
 
@@ -124,6 +131,7 @@ export default class Serve extends Command {
     const apiEndpointPath = '/graphql';
     const graphiqlClientPath = '/client';
     app.post(apiEndpointPath, expressMiddleware(handler as GraphQLHandler));
+
     app.use(
       graphiqlClientPath,
       graphiqlMiddleware(
@@ -160,7 +168,7 @@ export default class Serve extends Command {
 
     const { config, errors } = loadConfig(flags.config);
 
-    const headers = { ...config?.schema?.headers, ...collapseHeaders(flags.header) };
+    const schemaHeaders = { ...config?.schema?.headers, ...collapseHeaders(flags.header) };
 
     if (config && errors && errors.length) {
       this.warn(
@@ -169,14 +177,8 @@ export default class Serve extends Command {
     }
 
     const schemaPath = flags.schema ?? config?.schema?.path;
-
-    if (!schemaPath) {
-      this.error('A GraphQLSchema is required, specify a schema via a gqlmocks config or --schema flag');
-    }
-
     const handlerPath = flags.handler ?? config?.handler?.path;
 
-    const schema = await createSchemaFromLocation(schemaPath, headers);
     const middlewares: ResolverMapMiddleware[] = [];
 
     if (flags.fake) {
@@ -185,7 +187,7 @@ export default class Serve extends Command {
 
     const start = async () => {
       const up = async () => {
-        this.server = await this.startServer({ handlerPath, schema, port, middlewares });
+        this.server = await this.startServer({ handlerPath, schemaPath, schemaHeaders, port, middlewares });
       };
 
       if (this.server) {

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -22,7 +22,7 @@ import {
   schema as schemaFlag,
   handler as handlerFlag,
 } from '../lib/common-flags';
-const cors = require('cors');
+import cors from 'cors';
 
 function refreshModuleOnChange(module: string, cb: any) {
   watchFile(resolve(module), () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6032,6 +6032,11 @@
   resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.4.1.tgz#bfd02c1f2224567676c1545199f87c3a861d878d"
   integrity sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==
 
+"@types/cors@^2.8.12":
+  version "2.8.12"
+  resolved "https://registry.yarnpkg.com/@types/cors/-/cors-2.8.12.tgz#6b2c510a7ad7039e98e7b8d3d6598f4359e5c080"
+  integrity sha512-vt+kDhq/M2ayberEtJcIN/hxXy1Pk+59g2FV/ZQceeaTyCtCucjL2Q7FXlFjtWn4n15KCr1NE2lNNFhp0lEThw==
+
 "@types/debug@^4.1.7":
   version "4.1.7"
   resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.7.tgz#7cc0ea761509124709b8b2d1090d8f6c17aadb82"


### PR DESCRIPTION
Make either `--handler` or `--schema` flag required instead of both. This pull request also manually applies the falso middleware to either the in memory graphql handler created *or* by patching it into the `middlewares` array from the handler loaded by path.

## CHANGELOG
### `gqlmocks`
```markdown changelog(gqlmocks)
* (fix) Make `serve` command work with either `--handler` or `--schema` flag instead of both being required
* (fix) Allow false middleware via `--fake` on serve command to be applied to a handler specified by path
```
