### PR TITLE
Bump to node 16

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions/setup-node@v1
       with:
-        node-version: 14
+        node-version: 16
     - name: yarn & test
       env:
         CODE_EXAMPLE_ENV: test

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "packages/*"
   ],
   "engines": {
-    "node": ">= 14.0.0"
+    "node": ">= 16.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.11.6",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -48,7 +48,7 @@
     "typescript": "^4.5.5"
   },
   "engines": {
-    "node": ">= 14.0.0"
+    "node": ">= 16.0.0"
   },
   "files": [
     "/bin",

--- a/packages/docs/code-examples/home/handler.source.js
+++ b/packages/docs/code-examples/home/handler.source.js
@@ -5,74 +5,76 @@ import { logWrapper } from 'graphql-mocks/wrapper';
 import graphqlSchema from './schema';
 import { field } from 'graphql-mocks/highlight';
 
-const paper = new Paper(graphqlSchema);
+export function createHandler() {
+  const paper = new Paper(graphqlSchema);
 
-paper.mutate(({ create }) => {
-  // create characters
-  const mike = create('Character', { name: 'Mike Wazowski' });
-  const boo = create('Character', { name: 'Boo' });
-  const joe = create('Character', { name: 'Joe Gardner' });
-  const moonwind = create('Character', { name: 'Moonwind' });
+  paper.mutate(({ create }) => {
+    // create characters
+    const mike = create('Character', { name: 'Mike Wazowski' });
+    const boo = create('Character', { name: 'Boo' });
+    const joe = create('Character', { name: 'Joe Gardner' });
+    const moonwind = create('Character', { name: 'Moonwind' });
 
-  // create films with characters
-  create('Movie', {
-    name: 'Monsters, Inc.',
-    characters: [boo, mike],
-    year: '2001',
+    // create films with characters
+    create('Movie', {
+      name: 'Monsters, Inc.',
+      characters: [boo, mike],
+      year: '2001',
+    });
+
+    create('Movie', {
+      name: 'Soul',
+      characters: [joe, moonwind],
+      year: '2020',
+    });
   });
 
-  create('Movie', {
-    name: 'Soul',
-    characters: [joe, moonwind],
-    year: '2020',
+  // Check the console to see logging applied to only root-query resolvers!
+  const loggerMiddleware = embed({ wrappers: [logWrapper], highlight: (h) => h.include(field(['*', '*'])) });
+
+  // can be used for overrides or Mutations
+  const resolverMap = {
+    Query: {
+      movies(_root, args, context) {
+        const { paper } = extractDependencies(context, ['paper']);
+        let movies = paper.data.Movie;
+
+        if (args.name) {
+          movies = movies.filter((movie) => movie?.name?.startsWith(args.name));
+        }
+
+        return movies;
+      },
+    },
+
+    Mutation: {
+      create(_root, { name, year, characterIds }, context) {
+        const { paper } = extractDependencies(context, ['paper']);
+        return paper.mutate(({ create, getStore }) => {
+          const store = getStore();
+
+          const characters = characterIds
+            .map((id) => store.data.Character.find((character) => character.id === id))
+            .filter(Boolean);
+
+          return create('Movie', { name, year, characters });
+        });
+      },
+
+      createCharacter(_root, { name }, context) {
+        const { paper } = extractDependencies(context, ['paper']);
+        return paper.mutate(({ create }) => create('Character', { name }));
+      },
+    },
+  };
+
+  // export the composed GraphQL Handler
+  return new GraphQLHandler({
+    resolverMap,
+    middlewares: [loggerMiddleware],
+    dependencies: {
+      graphqlSchema,
+      paper,
+    },
   });
-});
-
-// Check the console to see logging applied to only root-query resolvers!
-const loggerMiddleware = embed({ wrappers: [logWrapper], highlight: (h) => h.include(field(['*', '*'])) });
-
-// can be used for overrides or Mutations
-const resolverMap = {
-  Query: {
-    movies(_root, args, context) {
-      const { paper } = extractDependencies(context, ['paper']);
-      let movies = paper.data.Movie;
-
-      if (args.name) {
-        movies = movies.filter((movie) => movie?.name?.startsWith(args.name));
-      }
-
-      return movies;
-    },
-  },
-
-  Mutation: {
-    create(_root, { name, year, characterIds }, context) {
-      const { paper } = extractDependencies(context, ['paper']);
-      return paper.mutate(({ create, getStore }) => {
-        const store = getStore();
-
-        const characters = characterIds
-          .map((id) => store.data.Character.find((character) => character.id === id))
-          .filter(Boolean);
-
-        return create('Movie', { name, year, characters });
-      });
-    },
-
-    createCharacter(_root, { name }, context) {
-      const { paper } = extractDependencies(context, ['paper']);
-      return paper.mutate(({ create }) => create('Character', { name }));
-    },
-  },
-};
-
-// export the composed GraphQL Handler
-export default new GraphQLHandler({
-  resolverMap,
-  middlewares: [loggerMiddleware],
-  dependencies: {
-    graphqlSchema,
-    paper,
-  },
-});
+}

--- a/packages/docs/docusaurus.config.js
+++ b/packages/docs/docusaurus.config.js
@@ -3,9 +3,6 @@
 
 const path = require('path');
 
-// needed to polyfill Events on the server
-require('event-target-polyfill');
-
 module.exports = {
   title: 'graphql-mocks',
   tagline: 'GraphQL Mock API Framework',

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -20,7 +20,7 @@
     "build:docs": "CODE_EXAMPLE_ENV=docs docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "yarn clean && CODE_EXAMPLE_ENV=docs docusaurus deploy",
-    "test": "CODE_EXAMPLE_ENV=test mocha --require \"event-target-polyfill\" \"./code-examples/**/*.test.js\"",
+    "test": "CODE_EXAMPLE_ENV=test mocha \"./code-examples/**/*.test.js\"",
     "copy-cli-readme": "cp ../cli/README.md docs/cli/_readme.md"
   },
   "dependencies": {
@@ -53,7 +53,6 @@
     "babel-plugin-codegen": "^4.0.1",
     "chai": "^4.2.0",
     "core-js": "^3.6.5",
-    "event-target-polyfill": "^0.0.3",
     "globby": "^11.0.1",
     "mocha": "^8.0.1",
     "prettier": "^2.0.5",

--- a/packages/docs/src/pages/index.jsx
+++ b/packages/docs/src/pages/index.jsx
@@ -8,7 +8,6 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 import styles from './styles.module.css';
 import GraphiQL from 'graphiql';
 import 'graphiql/graphiql.css';
-import graphqlHandler from '../../code-examples/home/handler.source';
 
 const defaultQuery = `{
   movies(name:"Mo") {
@@ -19,6 +18,9 @@ const defaultQuery = `{
     }
   }
 }`;
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function, valid-typeof
+let Handler = typeof window === 'undefined' ? () => {} : import('../../code-examples/home/handler.source');
 
 function Home() {
   const context = useDocusaurusContext();
@@ -149,7 +151,8 @@ function Home() {
                 }}
                 query={defaultQuery}
                 docExplorerOpen={false}
-                fetcher={(data) => {
+                fetcher={async (data) => {
+                  let graphqlHandler = (await Handler).createHandler();
                   return graphqlHandler.query(data.query).then((result) => {
                     return result;
                   });

--- a/packages/falso/package.json
+++ b/packages/falso/package.json
@@ -22,7 +22,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">= 14.0.0"
+    "node": ">= 16.0.0"
   },
   "devDependencies": {
     "@ngneat/falso": "^5.3.0",

--- a/packages/graphql-mocks/package.json
+++ b/packages/graphql-mocks/package.json
@@ -22,7 +22,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">= 14.0.0"
+    "node": ">= 16.0.0"
   },
   "dependencies": {
     "ramda": "^0.28.0"

--- a/packages/mirage/package.json
+++ b/packages/mirage/package.json
@@ -22,7 +22,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">= 14.0.0"
+    "node": ">= 16.0.0"
   },
   "dependencies": {
     "ramda": "^0.28.0"

--- a/packages/network-cypress/package.json
+++ b/packages/network-cypress/package.json
@@ -23,7 +23,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">= 14.0.0"
+    "node": ">= 16.0.0"
   },
   "devDependencies": {
     "axios": "^0.27.2",

--- a/packages/network-express/package.json
+++ b/packages/network-express/package.json
@@ -22,7 +22,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">= 14.0.0"
+    "node": ">= 16.0.0"
   },
   "devDependencies": {
     "@types/express": "^4.17.13",

--- a/packages/network-msw/package.json
+++ b/packages/network-msw/package.json
@@ -22,7 +22,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">= 14.0.0"
+    "node": ">= 16.0.0"
   },
   "devDependencies": {
     "execa": "^5.1.1",

--- a/packages/network-nock/package.json
+++ b/packages/network-nock/package.json
@@ -22,7 +22,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">= 14.0.0"
+    "node": ">= 16.0.0"
   },
   "devDependencies": {
     "@types/nock": "^11.1.0",

--- a/packages/network-pretender/package.json
+++ b/packages/network-pretender/package.json
@@ -21,7 +21,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">= 14.0.0"
+    "node": ">= 16.0.0"
   },
   "devDependencies": {
     "pretender": "^3.4.7"

--- a/packages/paper/package.json
+++ b/packages/paper/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "lint": "eslint \"./src/**/*.ts\"",
     "pretest": "tsc --noEmit && yarn lint",
-    "test": "TS_NODE_PROJECT=\"./test/tsconfig.json\" mocha -r \"event-target-polyfill\" -r ts-node/register \"./test/**/*.test.ts\"",
+    "test": "TS_NODE_PROJECT=\"./test/tsconfig.json\" mocha -r ts-node/register \"./test/**/*.test.ts\"",
     "clean": "rimraf ./dist",
     "copy-pjson": "node scripts/copy-scrubbed-pjson",
     "copy-readme": "cp README.md dist/README.md",
@@ -22,7 +22,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">= 14.0.0"
+    "node": ">= 16.0.0"
   },
   "dependencies": {
     "immer": "^9.0.6",
@@ -32,9 +32,6 @@
   },
   "peerDependencies": {
     "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
-  },
-  "optionalDependencies": {
-    "event-target-polyfill": "^0.0.3"
   },
   "devDependencies": {
     "@types/ramda": "^0.28.12",

--- a/packages/sinon/package.json
+++ b/packages/sinon/package.json
@@ -22,7 +22,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">= 14.0.0"
+    "node": ">= 16.0.0"
   },
   "devDependencies": {
     "@types/sinon": "^10.0.2",

--- a/templates/new-package/package.json
+++ b/templates/new-package/package.json
@@ -21,7 +21,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">= 14.0.0"
+    "node": ">= 16.0.0"
   },
   "devDependencies": {
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -11695,11 +11695,6 @@ eval@^0.1.4:
   dependencies:
     require-like ">= 0.1.1"
 
-event-target-polyfill@^0.0.3:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/event-target-polyfill/-/event-target-polyfill-0.0.3.tgz#ed373295f3b257774b5d75afb2599331d9f3406c"
-  integrity sha512-ZMc6UuvmbinrCk4RzGyVmRyIsAyxMRlp4CqSrcQRO8Dy0A9ldbiRy5kdtBj4OtP7EClGdqGfIqo9JmOClMsGLQ==
-
 event-target-shim@^5.0.0:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"


### PR DESCRIPTION
Bumps from Node to 14 to 16 across all packages. It also gets rid of the  `event-target-polyfill` as it's no longer needed as of Node 15. One thing that was caught with tests though is that Node's native usage of `EventTarget` and `Event` is that any event has to be an instance of `Event` and not a subclass.

## CHANGELOG

<!--
  Include any changelog entries one per package in a bulleted list
  as a (feature), (fix) or (breaking) with breaking changes at the
  top.

  * (breaking) list breaking changes first
  * (feature) added a new feature
  * (fix) fixed bug
-->

### `graphql-paper`
```markdown changelog(graphql-paper)
* (breaking) Bump from Node 14 to 16
```

### `gqlmocks`
```markdown changelog(gqlmocks)
* (breaking) Bump from Node 14 to 16
```

### `graphql-mocks`
```markdown changelog(graphql-mocks)
* (breaking) Bump from Node 14 to 16
```

### `@graphql-mocks/falso`
```markdown changelog(@graphql-mocks/falso)
* (breaking) Bump from Node 14 to 16
```

### `@graphql-mocks/network-cypress`
```markdown changelog(@graphql-mocks/network-cypress)
* (breaking) Bump from Node 14 to 16
```

### `@graphql-mocks/network-pretender`
```markdown changelog(@graphql-mocks/network-pretender)
* (breaking) Bump from Node 14 to 16
```

### `@graphql-mocks/network-express`
```markdown changelog(@graphql-mocks/network-express)
* (breaking) Bump from Node 14 to 16
```

### `@graphql-mocks/network-nock`
```markdown changelog(@graphql-mocks/network-nock)
* (breaking) Bump from Node 14 to 16
```

### `@graphql-mocks/mirage`
```markdown changelog(@graphql-mocks/mirage)
* (breaking) Bump from Node 14 to 16
```

### `@graphql-mocks/network-nock`
```markdown changelog(@graphql-mocks/network-nock)
* (breaking) Bump from Node 14 to 16
```

### `@graphql-mocks/sinon`
```markdown changelog(@graphql-mocks/sinon)
* (breaking) Bump from Node 14 to 16
```


