### PR TITLE
Fix falso middleware handling of abstract types (interfaces and unions)

### DIFF
--- a/packages/docs/docs/highlight/available-highlighters.md
+++ b/packages/docs/docs/highlight/available-highlighters.md
@@ -165,16 +165,45 @@ This can be done by either calling the highlighter with no arguments, or by prov
 
 ```js
 import { HIGHLIGHT_ALL } from 'graphql-mocks/highlight';
-
 hi(graphqlSchema).include(
   // by specifying no arguments, all interfaces are highlighted
   interfaces(),
-
   // alternatively, the HIGHLIGHT_ALL will explicitly
   // highlight all interfaces also
   interfaces(HIGHLIGHT_ALL)
 );
 ```
+
+## `interfaceField`
+Package: `graphql-mocks`
+
+```js
+import { interfaceField } from 'graphql-mocks/highlight';
+```
+
+This highlighter highlights interfaces *with their fields* on the GraphQL Schema.
+
+**Note:** This is different than the `interfaces` highlighter which highlights the interface type name only.
+
+By default all interfaces with their fields will be highlighted when no arguments passed in:
+
+```js
+hi(graphqlSchema).include(
+  interfaceField()
+);
+```
+
+Specific interfaces with fields can be highlighted:
+
+```js
+hi(graphqlSchema).include(
+  interfaceField(['Purchasable', 'cost'], ['Commentable', 'comment'])
+);
+```
+
+### Highlight All
+`interfaceField` supports the same options for wildcard highlighting all as the [`field` highligher](/docs/highlight/available-highlighters#wildcard-highlighting).
+
 
 ## `union`
 Package: `graphql-mocks`

--- a/packages/falso/package.json
+++ b/packages/falso/package.json
@@ -9,7 +9,6 @@
   "license": "MIT",
   "scripts": {
     "lint": "eslint \"./src/**/*.ts\" \"./test/**/*.ts\"",
-    "pretest": "tsc --noEmit && yarn lint",
     "test": "TS_NODE_PROJECT=\"./test/tsconfig.json\" mocha -r ts-node/register \"./test/**/*.test.ts\"",
     "clean": "rimraf ./dist",
     "copy-pjson": "node scripts/copy-scrubbed-pjson",

--- a/packages/falso/src/falso-middleware.ts
+++ b/packages/falso/src/falso-middleware.ts
@@ -4,7 +4,7 @@ import { highlightAllCallback } from 'graphql-mocks/resolver-map/utils';
 import { falsoFieldResolver } from './falso-field-resolver';
 import { FalsoMiddlewareOptions } from './types';
 import { falsoTypeResolver } from './falso-type-resolver';
-import { fromResolverMap, combine, union, interfaces, field } from 'graphql-mocks/highlight';
+import { fromResolverMap, combine, union, interfaces, interfaceField, field } from 'graphql-mocks/highlight';
 import { coerceHighlight, walk } from 'graphql-mocks/highlight/utils';
 import { setResolver } from 'graphql-mocks/resolver-map';
 
@@ -20,8 +20,9 @@ export function falsoMiddleware(options?: FalsoMiddlewareOptions): ResolverMapMi
       highlight = highlight.exclude(fromResolverMap(resolverMap));
     }
 
-    const fieldResolvableHighlight = highlight.filter(field());
+    const fieldResolvableHighlight = highlight.filter(field()).exclude(interfaceField());
     const fieldResolver = falsoFieldResolver(falsoOptions);
+
     await walk(graphqlSchema, fieldResolvableHighlight.references, ({ reference }) => {
       setResolver(resolverMap, reference, fieldResolver, {
         graphqlSchema,

--- a/packages/graphql-mocks/src/highlight/highlighter/interface-field.ts
+++ b/packages/graphql-mocks/src/highlight/highlighter/interface-field.ts
@@ -1,0 +1,45 @@
+import { GraphQLSchema, isInterfaceType } from 'graphql';
+import { HighlighterFactory, Highlighter, FieldReference } from '../types';
+import { isEqual } from '../utils';
+import { HIGHLIGHT_ALL } from './constants';
+import { field } from './field';
+
+export class InterfaceFieldHighlighter implements Highlighter {
+  targets: FieldReference[];
+
+  constructor(targets: FieldReference[]) {
+    if (targets.length === 0) {
+      targets = [[HIGHLIGHT_ALL, HIGHLIGHT_ALL]] as FieldReference[];
+    }
+
+    this.targets = targets;
+  }
+
+  mark(schema: GraphQLSchema): FieldReference[] {
+    return InterfaceFieldHighlighter.expandTargets(schema, this.targets);
+  }
+
+  static expandTargets(schema: GraphQLSchema, targets: FieldReference[]): FieldReference[] {
+    const interfaceTypes = Object.values(schema.getTypeMap()).filter(isInterfaceType);
+    const fieldReferences = field(...targets).mark(schema);
+
+    const interfaceTypeNamesAndFields = interfaceTypes.flatMap((interfaceType) => {
+      const interfaceName = interfaceType.name;
+      const interfaceFields = Object.values(interfaceType.getFields()).map((interfaceField) => {
+        const interfaceFieldName = interfaceField.name;
+        return [interfaceName, interfaceFieldName] as FieldReference;
+      });
+
+      return [...interfaceFields];
+    });
+
+    return interfaceTypeNamesAndFields.filter((interfaceFieldReference) => {
+      const found = fieldReferences.find((allFieldReference) => isEqual(allFieldReference, interfaceFieldReference));
+      return Boolean(found);
+    });
+  }
+}
+
+export const interfaceField: HighlighterFactory = function type(...interfaceNames: FieldReference[]) {
+  return new InterfaceFieldHighlighter(interfaceNames);
+};

--- a/packages/graphql-mocks/src/highlight/highlighter/interfaces.ts
+++ b/packages/graphql-mocks/src/highlight/highlighter/interfaces.ts
@@ -3,9 +3,9 @@ import { TypeReference, HighlighterFactory, Highlighter } from '../types';
 import { HIGHLIGHT_ALL } from './constants';
 
 export class InterfaceHighlighter implements Highlighter {
-  targets: string[];
+  targets: TypeReference[];
 
-  constructor(targets: string[]) {
+  constructor(targets: TypeReference[]) {
     if (targets.length === 0) {
       targets = [HIGHLIGHT_ALL];
     }
@@ -17,7 +17,7 @@ export class InterfaceHighlighter implements Highlighter {
     return InterfaceHighlighter.expandTargets(schema, this.targets);
   }
 
-  static expandTargets(schema: GraphQLSchema, targets: string[]): TypeReference[] {
+  static expandTargets(schema: GraphQLSchema, targets: TypeReference[]): TypeReference[] {
     const interfaceTypeNames = Object.values(schema.getTypeMap())
       .filter(isInterfaceType)
       .map((i) => i.name);
@@ -30,6 +30,6 @@ export class InterfaceHighlighter implements Highlighter {
   }
 }
 
-export const interfaces: HighlighterFactory = function type(...interfaceNames: string[]) {
+export const interfaces: HighlighterFactory = function type(...interfaceNames: TypeReference[]) {
   return new InterfaceHighlighter(interfaceNames);
 };

--- a/packages/graphql-mocks/src/highlight/index.ts
+++ b/packages/graphql-mocks/src/highlight/index.ts
@@ -3,6 +3,7 @@ export { combine } from './highlighter/combine';
 export { field } from './highlighter/field';
 export { fromResolverMap } from './highlighter/from-resolver-map';
 export { interfaces } from './highlighter/interfaces';
+export { interfaceField } from './highlighter/interface-field';
 export { reference } from './highlighter/reference';
 export { resolvesTo } from './highlighter/resolves-to';
 export { type } from './highlighter/type';

--- a/packages/graphql-mocks/test/unit/highlight/highlighter/interface-field.test.ts
+++ b/packages/graphql-mocks/test/unit/highlight/highlighter/interface-field.test.ts
@@ -1,0 +1,77 @@
+import { buildSchema } from 'graphql';
+import { expect } from 'chai';
+import { interfaceField } from '../../../../src/highlight/highlighter/interface-field';
+import { HIGHLIGHT_ALL } from '../../../../src/highlight/highlighter/constants';
+
+const schema = buildSchema(`
+  schema {
+    query: Query
+  }
+
+  type Query {
+    pet: Pet!
+  }
+
+  interface Pet {
+    name: String!
+  }
+
+  interface Canine {
+    type: String!
+    domesticated: Boolean!
+  }
+
+  interface Feline {
+    type: String!
+    domesticated: Boolean!
+  }
+
+  type Cat implements Pet & Feline {
+    name: String!
+    hasHair: Boolean!
+  }
+
+  type Dog implements Pet & Canine {
+    name: String!
+    type: String!
+    knowsTricks: Boolean!
+  }
+
+  type Wolf implements Canine {
+    name: String!
+    type: String!
+    knowsTricks: Boolean!
+  }
+`);
+
+describe('highlight/highlighter/interfaces', function () {
+  const allInterfaceFields = [
+    ['Pet', 'name'],
+    ['Canine', 'type'],
+    ['Canine', 'domesticated'],
+    ['Feline', 'type'],
+    ['Feline', 'domesticated'],
+  ];
+
+  it('highlights all interface types and fields by default without arguments', function () {
+    expect(interfaceField().mark(schema)).to.deep.equal(allInterfaceFields);
+  });
+
+  it('highlights all interface types when passed the HIGHLIGHT_ALL argument', function () {
+    expect(interfaceField([HIGHLIGHT_ALL, HIGHLIGHT_ALL]).mark(schema)).to.deep.equal(allInterfaceFields);
+  });
+
+  it('highlights specified interfaces fields with HIGHLIGHT_ALL for type', function () {
+    expect(interfaceField([HIGHLIGHT_ALL, 'domesticated']).mark(schema)).to.deep.equal([
+      ['Canine', 'domesticated'],
+      ['Feline', 'domesticated'],
+    ]);
+  });
+
+  it('highlights a specified type with all interfaces fields via HIGHLIGHT_ALL for fields', function () {
+    expect(interfaceField(['Canine', HIGHLIGHT_ALL]).mark(schema)).to.deep.equal([
+      ['Canine', 'type'],
+      ['Canine', 'domesticated'],
+    ]);
+  });
+});


### PR DESCRIPTION
Fixes the issue where interface types and fields were being picked up by the falso middleware and it was trying to attach a field resolver. By adding a new highlighter for interface fields these can be excluded so that the middleware only installs a field resolver for object types.

Fixes #167

## CHANGELOG

<!--
  Include any changelog entries one per package in a bulleted list
  as a (feature), (fix) or (breaking) with breaking changes at the
  top.

  * (breaking) list breaking changes first
  * (feature) added a new feature
  * (fix) fixed bug
-->

### `graphql-mocks`
```markdown changelog(graphql-mocks)
* (feature) Add a new `interfaceField` highlighter for highlighting interfaces with fields. This is different from the `interfaces`  highlighter which returns only the interfaces typenames themselves (for type resolvers). See highlighter documentation for more information.
```

### `@graphql-mocks/falso`
```markdown changelog(graphql-mocks)
* (fix) Fix falso middleware handling around automatic faking with unions and interfaces
```