### PR TITLE
Add custom scalar support

### DIFF
--- a/packages/docs/docs/handler/using-custom-scalars.md
+++ b/packages/docs/docs/handler/using-custom-scalars.md
@@ -1,0 +1,79 @@
+---
+id: custom-scalars
+title: Using Custom Scalars
+---
+
+GraphQL comes with the following scalars: `Int`, `Float`, `String`, `Boolean` and `ID` (see [official documentation](https://graphql.org/learn/schema/#scalar-types) for more information). Outside of these GraphQL supports adding custom scalars.
+
+Custom Scalars can be defined in your schema and then the implementation can be applied to the `GraphQLHandler` via a *Scalar Map*.
+
+## Defining Custom Scalars
+
+Custom scalars can be specified in your GraphQL Schema, for example adding a custom `JSON` scalar and then using it with the `arbitraryJSON` field on the `Query` type.
+
+```graphql
+# added to the schema!
+scalar JSON
+
+schema {
+  query: Query
+}
+
+type Query {
+  # used elsewhere in the schema
+  arbitraryJSON: JSON!
+}
+```
+
+## Providing the Scalar Implementation
+
+This works for an initial definition but the actual parsing and serialization of the scalar has to be defined programatically. In GraphQL Mocks this is specified by passing a *Scalar Map* to the GraphQL Handler.
+
+The keys for the scalar map are the name of the scalar and the value is either a `GraphQLScalarType` which can be imported from another library or by providing the required functions necessary for handling custom scalars.
+
+This is an example of using a custom scalar imported from a package, in this case the JSON scalar from `graphql-type-json`.
+```js
+import GraphQLJSON from 'graphql-type-json';
+
+const scalarMap = {
+  JSON: GraphQLJSON
+};
+```
+
+Alternatively, for a quick way of creating a custom scalar provide the `parseLiteral`, `parseValue`, and `serialize` functions (see Apollo documentation for [Custom Scalars](https://www.apollographql.com/docs/apollo-server/schema/custom-scalars) for details on defining these functions):
+```js
+const scalarMap = {
+  JSON: {
+    parseLiteral(outputValue) {
+      // implementation
+    },
+    
+    parseValue(inputValue) {
+      // implementation
+    },
+
+    serialize(valueNode, variables) {
+      // implementation
+    }
+  }
+};
+```
+
+## Adding the Scalar Map to the `GraphQLHandler`
+
+A custom scalar map is passed as one of the options to the `GraphQLHandler`:
+
+```js
+import { GraphQLHandler } from 'graphql-mocks';
+import { graphqlSchema } from './schema';
+import { scalarMap } from './scalar-map';
+
+const handler = new GraphQLHandler({
+  scalarMap,
+  dependencies: {
+    graphqlSchema
+  }
+});
+```
+
+Now the custom scalars can be used by the `GraphQLHandler` for any queries.

--- a/packages/docs/sidebars.js
+++ b/packages/docs/sidebars.js
@@ -9,7 +9,12 @@ module.exports = {
       ],
     },
     {
-      'GraphQL Handler': ['handler/introducing-handler', 'handler/using-middlewares', 'handler/handler-state'],
+      'GraphQL Handler': [
+        'handler/introducing-handler',
+        'handler/using-middlewares',
+        'handler/handler-state',
+        'handler/custom-scalars',
+      ],
     },
     {
       'Resolver & Wrappers ': [

--- a/packages/graphql-mocks/src/graphql/type-utils/is-scalar-definition.ts
+++ b/packages/graphql-mocks/src/graphql/type-utils/is-scalar-definition.ts
@@ -1,0 +1,17 @@
+import { GraphQLScalarType, isScalarType } from 'graphql';
+import { BasicScalarDefinition } from '../../types';
+
+export function isScalarDefinition(
+  possibleScalarDefinition: unknown,
+): possibleScalarDefinition is GraphQLScalarType | BasicScalarDefinition {
+  if (typeof possibleScalarDefinition !== 'object') {
+    return false;
+  }
+
+  const hasRequiredScalarDefinitionProperties =
+    possibleScalarDefinition &&
+    'parseValue' in possibleScalarDefinition &&
+    'parseLiteral' in possibleScalarDefinition &&
+    'serialize' in possibleScalarDefinition;
+  return isScalarType(possibleScalarDefinition) || Boolean(hasRequiredScalarDefinitionProperties);
+}

--- a/packages/graphql-mocks/src/graphql/type-utils/is-scalar-definition.ts
+++ b/packages/graphql-mocks/src/graphql/type-utils/is-scalar-definition.ts
@@ -10,8 +10,9 @@ export function isScalarDefinition(
 
   const hasRequiredScalarDefinitionProperties =
     possibleScalarDefinition &&
-    'parseValue' in possibleScalarDefinition &&
-    'parseLiteral' in possibleScalarDefinition &&
-    'serialize' in possibleScalarDefinition;
+    ('parseValue' in possibleScalarDefinition ||
+      'parseLiteral' in possibleScalarDefinition ||
+      'serialize' in possibleScalarDefinition);
+
   return isScalarType(possibleScalarDefinition) || Boolean(hasRequiredScalarDefinitionProperties);
 }

--- a/packages/graphql-mocks/src/graphql/types.ts
+++ b/packages/graphql-mocks/src/graphql/types.ts
@@ -1,10 +1,11 @@
 import { GraphQLSchema, GraphQLArgs, DocumentNode } from 'graphql';
-import { ResolverMapMiddleware, ResolverMap } from '../types';
+import { ResolverMapMiddleware, ResolverMap, ScalarMap } from '../types';
 import { PackOptions } from '../pack/types';
 
 export type CreateGraphQLHandlerOptions = Partial<PackOptions> & {
   initialContext?: GraphQLArgs['contextValue'];
   resolverMap?: ResolverMap;
+  scalarMap?: ScalarMap;
   middlewares?: ResolverMapMiddleware[];
   dependencies: PackOptions['dependencies'] & { graphqlSchema: GraphQLSchema | DocumentNode | string };
 };

--- a/packages/graphql-mocks/src/graphql/utils/attach-scalars-to-schema.ts
+++ b/packages/graphql-mocks/src/graphql/utils/attach-scalars-to-schema.ts
@@ -23,6 +23,7 @@ export function attachScalarsToSchema(schema: GraphQLSchema, scalarMap: ScalarMa
     const schemaScalar = scalarTypeMap[scalarName];
 
     for (const key in scalarDefinition) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (schemaScalar as any)[key] = (scalarDefinition as any)[key];
     }
   }

--- a/packages/graphql-mocks/src/graphql/utils/attach-scalars-to-schema.ts
+++ b/packages/graphql-mocks/src/graphql/utils/attach-scalars-to-schema.ts
@@ -10,6 +10,7 @@ export function attachScalarsToSchema(schema: GraphQLSchema, scalarMap: ScalarMa
       [scalar.name]: scalar,
     };
   }, {});
+
   const resolverMapScalars = Object.keys(scalarMap).filter((type) => Object.keys(scalarTypeMap).includes(type));
 
   for (const scalarName of resolverMapScalars) {

--- a/packages/graphql-mocks/src/graphql/utils/attach-scalars-to-schema.ts
+++ b/packages/graphql-mocks/src/graphql/utils/attach-scalars-to-schema.ts
@@ -1,0 +1,29 @@
+import { GraphQLScalarType, GraphQLSchema, isScalarType } from 'graphql';
+import { ScalarMap } from '../../types';
+import { isScalarDefinition } from '../type-utils/is-scalar-definition';
+
+export function attachScalarsToSchema(schema: GraphQLSchema, scalarMap: ScalarMap): void {
+  const scalarTypesArray = Object.values(schema.getTypeMap()).filter(isScalarType);
+  const scalarTypeMap: Record<string, GraphQLScalarType> = scalarTypesArray.reduce((map, scalar) => {
+    return {
+      ...map,
+      [scalar.name]: scalar,
+    };
+  }, {});
+  const resolverMapScalars = Object.keys(scalarMap).filter((type) => Object.keys(scalarTypeMap).includes(type));
+
+  for (const scalarName of resolverMapScalars) {
+    const possibleScalar = scalarMap[scalarName];
+
+    if (!isScalarDefinition(possibleScalar)) {
+      continue;
+    }
+
+    const scalarDefinition = possibleScalar;
+    const schemaScalar = scalarTypeMap[scalarName];
+
+    for (const key in scalarDefinition) {
+      (schemaScalar as any)[key] = (scalarDefinition as any)[key];
+    }
+  }
+}

--- a/packages/graphql-mocks/src/graphql/utils/index.ts
+++ b/packages/graphql-mocks/src/graphql/utils/index.ts
@@ -1,5 +1,6 @@
 export { attachFieldResolversToSchema } from './attach-field-resolvers-to-schema';
 export { attachTypeResolversToSchema } from './attach-type-resolvers-to-schema';
 export { attachResolversToSchema } from './attach-resolvers-to-schema';
+export { attachScalarsToSchema } from './attach-scalars-to-schema';
 export { copySchema } from './copy-schema';
 export { createSchema } from './create-schema';

--- a/packages/graphql-mocks/src/types.ts
+++ b/packages/graphql-mocks/src/types.ts
@@ -27,9 +27,9 @@ export type ResolverInfo<Resolver extends FieldResolver = FieldResolver> = Param
 // Library Abstractions
 
 export type BasicScalarDefinition = {
-  serialize: GraphQLScalarType['serialize'];
-  parseValue: GraphQLScalarType['parseValue'];
-  parseLiteral: GraphQLScalarType['parseLiteral'];
+  serialize?: GraphQLScalarType['serialize'];
+  parseValue?: GraphQLScalarType['parseValue'];
+  parseLiteral?: GraphQLScalarType['parseLiteral'];
 };
 
 export type ScalarMap = {

--- a/packages/graphql-mocks/src/types.ts
+++ b/packages/graphql-mocks/src/types.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { GraphQLFieldResolver, GraphQLField, GraphQLTypeResolver } from 'graphql';
+import { GraphQLFieldResolver, GraphQLField, GraphQLTypeResolver, GraphQLScalarType } from 'graphql';
 
 import { PackOptions } from './pack/types';
 
@@ -25,6 +25,16 @@ export type ResolverContext = ManagedContext;
 export type ResolverInfo<Resolver extends FieldResolver = FieldResolver> = Parameters<Resolver>[3];
 
 // Library Abstractions
+
+export type BasicScalarDefinition = {
+  serialize: GraphQLScalarType['serialize'];
+  parseValue: GraphQLScalarType['parseValue'];
+  parseLiteral: GraphQLScalarType['parseLiteral'];
+};
+
+export type ScalarMap = {
+  [typename: string]: GraphQLScalarType | BasicScalarDefinition;
+};
 
 // the convention of using __resolveType on a ResolverMap is borrowed from `graphql-tools`
 export type ResolverMap<TFieldResolver = FieldResolver, TTypeResolver = TypeResolver> = {

--- a/packages/graphql-mocks/test/unit/graphql/utils.test.ts
+++ b/packages/graphql-mocks/test/unit/graphql/utils.test.ts
@@ -128,11 +128,11 @@ describe('graphql/utils', function () {
     });
 
     it('adds a custom scalar by scalar definition', function () {
-      let serialize = spy();
-      let parseLiteral = spy();
-      let parseValue = spy();
+      const serialize = spy();
+      const parseLiteral = spy();
+      const parseValue = spy();
 
-      let scalarDefinition = {
+      const scalarDefinition = {
         serialize,
         parseLiteral,
         parseValue,
@@ -149,9 +149,9 @@ describe('graphql/utils', function () {
     });
 
     it('adds a custom scalar by GraphQLScalarType instance', function () {
-      let serialize = spy();
-      let parseLiteral = spy();
-      let parseValue = spy();
+      const serialize = spy();
+      const parseLiteral = spy();
+      const parseValue = spy();
 
       const scalarType = new GraphQLScalarType({
         name: 'JSON',

--- a/packages/graphql-mocks/test/unit/wrapper/latency.test.ts
+++ b/packages/graphql-mocks/test/unit/wrapper/latency.test.ts
@@ -49,6 +49,7 @@ describe('wrapper/latency', function () {
 
   it('delays for a specific amount of milliseconds', async function () {
     const latency = 1000;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const wrappedResolver = await latencyWrapper(latency).wrap(resolverSpy, {} as any);
     timer.start();
     await wrappedResolver(anyArg, anyArg, anyArg, anyArg);
@@ -60,6 +61,7 @@ describe('wrapper/latency', function () {
 
   it('delays for a range of milliseconds', async function () {
     const latency: [number, number] = [1000, 1500];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const wrappedResolver = await latencyWrapper(latency).wrap(resolverSpy, {} as any);
     timer.start();
     await wrappedResolver(anyArg, anyArg, anyArg, anyArg);


### PR DESCRIPTION
This pull request adds support for custom scalars. These are added to the `GraphQLHandler` via a _Scalar Map_.

Roughly, it looks something like this.
```js
import dateScalar from 'graphql-date-scalar'; // example package

const scalarMap = {
  Date: dateScalar
};

const handler = new GraphQLHandler({
  scalarMap,
  // ...
});
```

The pull request includes documentation with more examples and references.

- [x] Add integration test with an actual custom scalar

## CHANGELOG
### `graphql-mocks`
```markdown changelog(graphql-mocks)
* (feature) Add support for custom scalars
```
