### PR TITLE
Use local reference `isEqual` helper for references instead of ramda equals

### DIFF
--- a/packages/graphql-mocks/src/highlight/utils/unique.ts
+++ b/packages/graphql-mocks/src/highlight/utils/unique.ts
@@ -1,11 +1,11 @@
 import { Reference } from '../types';
-import { equals } from 'ramda';
+import { isEqual } from './is-equal';
 
 export function unique(fieldReferences: Reference[]): Reference[] {
   const uniques: Reference[] = [];
 
   fieldReferences.forEach((reference: Reference) => {
-    const match = uniques.find((uniqueReference) => equals(reference, uniqueReference));
+    const match = uniques.find((uniqueReference) => isEqual(reference, uniqueReference));
     if (!match) uniques.push(reference);
   });
 


### PR DESCRIPTION
Previously the `unique` highlight helper would use `equals` ramda for highlight reference comparisons. Turns out this is a very expensive way of comparing references _and_ this library already had a `isEqual` helper for comparing references that is much faster (and could possibly still be improved some).

This pull request swaps the ramda `equals` for the local library highlight reference comparison helper `isEqual`.

## Before
```
PerformanceMeasure {
  duration: 3987.551749944687
}
```

## After
```
PerformanceMeasure {
  duration: 107.58137512207031
}
```

The improvement is ~36x which is both great but also kind of unfortunate it wasn't caught before. The test used the `falsoMiddleware` and a schema with 200 types and 10 fields per type.

(Likely) fixes #226 

## CHANGELOG
### `graphql-mocks`
```markdown changelog(graphql-mocks)
* (feature) Improve performance around highlight reference comparisons
```
