### PR TITLE
Fix gqlmocks cli dynamic handling of typescript files

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "eslint-plugin-mocha": "^8.0.0",
     "eslint-plugin-prettier": "^3.1.4",
     "get-yarn-workspaces": "^1.0.2",
+    "graphql": "^16.2.0",
     "lerna": "^3.22.1",
     "mocha": "^8.1.3",
     "prettier": "^2.1.1",
@@ -53,7 +54,7 @@
     "rollup": "^2.56.0",
     "semver": "^7.3.5",
     "ts-node": "^9.0.0",
-    "typescript": "^4.1.0",
-    "graphql": "^16.2.0"
-  }
+    "typescript": "^4.1.0"
+  },
+  "dependencies": {}
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "@babel/core": "^7.17.5",
     "@babel/node": "^7.16.0",
+    "@babel/plugin-proposal-class-properties": "^7.18.6",
     "@babel/plugin-transform-typescript": "^7.16.8",
     "@babel/register": "^7.17.0",
     "@graphql-mocks/falso": "^0.5.1",
@@ -68,6 +69,9 @@
     "topicSeparator": " ",
     "commands": "./lib/commands",
     "bin": "gqlmocks",
+    "hooks": {
+      "init": "./lib/hooks/init"
+    },
     "plugins": [
       "@oclif/plugin-version",
       "@oclif/plugin-help"

--- a/packages/cli/src/hooks/init.ts
+++ b/packages/cli/src/hooks/init.ts
@@ -4,7 +4,14 @@
 module.exports = async function () {
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   require('@babel/register')({
-    presets: ['@babel/preset-typescript', ['@babel/preset-env', { modules: 'commonjs' }]],
+    presets: ['@babel/preset-typescript', ['@babel/preset-env', { targets: { node: 16 }, modules: 'cjs' }]],
+    plugins: ['@babel/plugin-proposal-class-properties'],
+    // ignore with an empty array is key for allowing transpilation outside of
+    // the current working directory. This is needed because the cli makes
+    // use of putting files in tmp directories and sometimes needs to require
+    // them from there and they might be in a .ts format
+    // see https://github.com/babel/babel/issues/8321
+    ignore: [],
     extensions: ['.js', '.ts'],
   });
 

--- a/packages/cli/src/lib/config/load-config.ts
+++ b/packages/cli/src/lib/config/load-config.ts
@@ -3,10 +3,7 @@ import { normalizeAbsolutePath } from '../normalize-absolute-path';
 import { validateConfig } from './validate-config';
 import { resolve } from 'path';
 
-export function loadConfig(
-  path?: string,
-  options?: { strict: boolean },
-): { config?: GqlMocksConfig; path?: string; errors: Error[] } {
+export function loadConfig(path?: string): { config?: GqlMocksConfig; path?: string; errors: Error[] } {
   let filePath: string | undefined;
   const extensions = ['json', 'js', 'ts'];
 

--- a/packages/cli/test/commands/config/generate.test.ts
+++ b/packages/cli/test/commands/config/generate.test.ts
@@ -6,9 +6,6 @@ import { unlinkSync as rm } from 'fs';
 import { testPackagePath, useTestPackage } from '../../test-helpers/package';
 
 describe('config/generate', function () {
-  // necessary for CI
-  this.timeout(20000);
-
   const testPackage = 'test-package-generate';
   const generateTestPkgDir = testPackagePath(testPackage);
   const findGeneratedConfig = () =>
@@ -35,7 +32,11 @@ describe('config/generate', function () {
     '/handler/path',
   ];
 
+  // 👋 Unfortunately this test takes a long time in CI even though it
+  // is quick locally.
+  // TODO: Investigate! And see if this timeout can be dropped somehow
   test
+    .timeout(30000)
     .stdout()
     .stderr()
     .command(['config:generate', ...configContentFlags])

--- a/yarn.lock
+++ b/yarn.lock
@@ -1480,7 +1480,7 @@
 
 "@babel/plugin-proposal-class-properties@^7.18.6":
   version "7.18.6"
-  resolved "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.18.6.tgz"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.18.6.tgz#b110f59741895f7ec21a6fff696ec46265c446a3"
   integrity sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==
   dependencies:
     "@babel/helper-create-class-features-plugin" "^7.18.6"
@@ -9799,30 +9799,10 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001135:
-  version "1.0.30001148"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001148.tgz"
-  integrity sha512-E66qcd0KMKZHNJQt9hiLZGE3J4zuTqE1OnU53miEVtylFbwOEmeA5OsRu90noZful+XGSQOni1aT2tiqu/9yYw==
-
-caniuse-lite@^1.0.30001125:
-  version "1.0.30001125"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001125.tgz"
-  integrity sha512-9f+r7BW8Qli917mU3j0fUaTweT3f3vnX/Lcs+1C73V+RADmFme+Ih0Br8vONQi3X0lseOe6ZHfsZLCA8MSjxUA==
-
-caniuse-lite@^1.0.30001280:
-  version "1.0.30001280"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001280.tgz"
-  integrity sha512-kFXwYvHe5rix25uwueBxC569o53J6TpnGu0BEEn+6Lhl2vsnAumRFWEBhDft1fwyo6m1r4i+RqA4+163FpeFcA==
-
-caniuse-lite@^1.0.30001332:
-  version "1.0.30001346"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001346.tgz"
-  integrity sha512-q6ibZUO2t88QCIPayP/euuDREq+aMAxFE5S70PkrLh0iTDj/zEhgvJRKC2+CvXY6EWc6oQwUR48lL5vCW6jiXQ==
-
-caniuse-lite@^1.0.30001400, caniuse-lite@^1.0.30001426:
-  version "1.0.30001434"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001434.tgz"
-  integrity sha512-aOBHrLmTQw//WFa2rcF1If9fa3ypkC1wzqqiKHgfdrXTWcU8C4gKVZT77eQAPWN1APys3+uQ0Df07rKauXGEYA==
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001125, caniuse-lite@^1.0.30001135, caniuse-lite@^1.0.30001280, caniuse-lite@^1.0.30001332, caniuse-lite@^1.0.30001400, caniuse-lite@^1.0.30001426:
+  version "1.0.30001439"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001439.tgz"
+  integrity sha512-1MgUzEkoMO6gKfXflStpYgZDlFM7M/ck/bgfVCACO5vnAf0fXoNVHdWtqGU+MYca+4bL9Z5bpOVmR33cWW9G2A==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
`gqlmocks` supports loading the `.ts` file format. It does this through an `init` hook. The `init` hook uses `@babel/register` so that every file being imported via  node `require` can be  transpiled on the fly. By using `@babel/preset-env` and `@babel/preset-typescript` this enables support for a wide variety features including transpiling module syntax (esmodules -> commonjs) and remove typescript type definitions, to try and ensure strong compatibility.

This pull request does two things:
1. Sets up oclif so that this hook actually gets called
2. Ensures that files outside of the current working directory can be included in transpilation

It was tested against the `./bin/run config generate` command locally after doing a fresh `yarn build`. Using `./bin/dev` would not show the bug because this bootstraps `ts-node`'s `register` on node's `resolve` and adds typescript support that way.

## CHANGELOG
### `gqlmocks`
```markdown changelog(gqlmocks)
* (fix) Fixed typescript support within the cli where `require` is used on a `.ts` file
```
