### PR TITLE
Fix cli readme generation to happen during the build process

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -152,7 +152,7 @@ DESCRIPTION
   Display help for gqlmocks.
 ```
 
-_See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v5.1.11/src/commands/help.ts)_
+_See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v5.1.12/src/commands/help.ts)_
 
 ## `gqlmocks schema fetch`
 
@@ -243,7 +243,7 @@ USAGE
 
 FLAGS
   -c, --config=<value>   path to config file
-  -f, --faker            use faker middlware for resolvers
+  -f, --fake             use @graphql-mocks/falso to fill in missing resolvers with fake data
   -h, --handler=<value>  path to file with graphql handler
   -p, --port=<value>     [default: 4444] Port to serve on
   -s, --schema=<value>   local path to graphql schema (relative or absolute), remote url (graphql schema file or graphql
@@ -256,13 +256,13 @@ DESCRIPTION
 EXAMPLES
   $ gqlmocks serve --schema ../schema.graphql
 
-  $ gqlmocks serve --schema ../schema.graphql --handler ../handler.ts
+  $ gqlmocks serve --handler ../handler.ts
 
-  $ gqlmocks serve --schema http://s3-bucket/schema.graphql --faker
+  $ gqlmocks serve --schema http://s3-bucket/schema.graphql --fake
 
-  $ gqlmocks serve --schema http://graphql-api/ --faker
+  $ gqlmocks serve --schema http://graphql-api/ --fake
 
-  $ gqlmocks serve --schema http://graphql-api/ --header "Authorization=Bearer token" --faker
+  $ gqlmocks serve --schema http://graphql-api/ --header "Authorization=Bearer token" --fake
 ```
 
 _See code: [src/commands/serve.ts](https://github.com/graphql-mocks/graphql-mocks/blob/main/packages/cli/src/commands/serve.ts)_

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -82,7 +82,7 @@
     "postpack": "rm -f oclif.manifest.json",
     "prepack": "rm -rf lib && oclif readme && yarn build",
     "test": "NODE_ENV=development mocha \"test/**/*.test.ts\"",
-    "build": "tsc && yarn copy-blueprints && yarn copy-readme && oclif manifest",
+    "build": "tsc && yarn copy-blueprints && oclif readme && yarn copy-readme && oclif manifest",
     "test-build": "mocha \"test/**/*.test.ts\"",
     "copy-blueprints": "mkdir -p lib/blueprints && cp -r src/blueprints lib",
     "copy-readme": "cp README.md lib/README.md"


### PR DESCRIPTION
The oclif readme command was being ran during prepack which means the README was lagging in being committed and used during the build process. This matters for the website that uses the committed and generated README.