### PR TITLE
Fix package json types references

### DIFF
--- a/packages/falso/package.json
+++ b/packages/falso/package.json
@@ -10,7 +10,8 @@
   "exports": {
     ".": {
       "import": "./dist/es/index.mjs",
-      "require": "./dist/index.js"
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
     }
   },
   "scripts": {

--- a/packages/graphql-mocks/package.json
+++ b/packages/graphql-mocks/package.json
@@ -9,59 +9,73 @@
   "exports": {
     ".": {
       "import": "./dist/es/index.mjs",
-      "require": "./dist/index.js"
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
     },
     "./graphql": {
       "import": "./dist/es/graphql/index.mjs",
-      "require": "./dist/graphql/index.js"
+      "require": "./dist/graphql/index.js",
+      "types": "./dist/graphql/index.d.ts"
     },
     "./graphql/type-utils": {
       "import": "./dist/es/graphql/type-utils/index.mjs",
-      "require": "./dist/graphql/type-utils/index.js"
+      "require": "./dist/graphql/type-utils/index.js",
+      "types": "./dist/graphql/type-utils/index.d.ts"
     },
     "./graphql/utils": {
       "import": "./dist/es/graphql/utils/index.mjs",
-      "require": "./dist/graphql/utils/index.js"
+      "require": "./dist/graphql/utils/index.js",
+      "types": "./dist/graphql/utils/index.d.ts"
     },
     "./highlight": {
       "import": "./dist/es/highlight/index.mjs",
-      "require": "./dist/highlight/index.js"
+      "require": "./dist/highlight/index.js",
+      "types": "./dist/highlight/index.d.ts"
     },
     "./highlight/utils": {
       "import": "./dist/es/highlight/utils/index.mjs",
-      "require": "./dist/highlight/utils/index.js"
+      "require": "./dist/highlight/utils/index.js",
+      "types": "./dist/highlight/utils/index.d.ts"
     },
     "./resolver-map": {
       "import": "./dist/es/resolver-map/index.mjs",
-      "require": "./dist/resolver-map/index.js"
+      "require": "./dist/resolver-map/index.js",
+      "types": "./dist/resolver-map/index.d.ts"
     },
     "./resolver-map/utils": {
       "import": "./dist/es/resolver-map/utils/index.mjs",
-      "require": "./dist/resolver-map/utils/index.js"
+      "require": "./dist/resolver-map/utils/index.js",
+      "types": "./dist/resolver-map/utils/index.d.ts"
     },
     "./resolver": {
       "import": "./dist/es/resolver/index.mjs",
-      "require": "./dist/resolver/index.js"
+      "require": "./dist/resolver/index.js",
+      "types": "./dist/resolver/index.d.ts"
     },
     "./resolver/utils": {
       "import": "./dist/es/resolver/utils/index.mjs",
-      "require": "./dist/resolver/utils/index.js"
+      "require": "./dist/resolver/utils/index.js",
+      "types": "./dist/resolver/utils/index.d.ts"
     },
     "./relay": {
       "import": "./dist/es/relay/index.mjs",
-      "require": "./dist/relay/index.js"
+      "require": "./dist/relay/index.js",
+      "types": "./dist/relay/index.d.ts"
     },
     "./pack": {
       "import": "./dist/es/pack/index.mjs",
-      "require": "./dist/pack/index.js"
+      "require": "./dist/pack/index.js",
+      "types": "./dist/pack/index.d.ts"
     },
     "./pack/utils": {
       "import": "./dist/es/pack/utils/index.mjs",
-      "require": "./dist/pack/utils/index.js"
+      "require": "./dist/pack/utils/index.js",
+      "types": "./dist/pack/utils/index.d.ts"
     },
     "./wrapper": {
       "import": "./dist/es/wrapper/index.mjs",
-      "require": "./dist/wrapper/index.js"
+      "require": "./dist/wrapper/index.js",
+      "types": "./dist/wrapper/index.d.ts"
     }
   },
   "license": "MIT",

--- a/packages/mirage/package.json
+++ b/packages/mirage/package.json
@@ -8,7 +8,8 @@
   "exports": {
     ".": {
       "import": "./dist/es/index.mjs",
-      "require": "./dist/index.js"
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
     }
   },
   "types": "dist/index.d.ts",

--- a/packages/network-cypress/package.json
+++ b/packages/network-cypress/package.json
@@ -8,7 +8,8 @@
   "exports": {
     ".": {
       "import": "./dist/es/index.mjs",
-      "require": "./dist/index.js"
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
     }
   },
   "types": "dist/index.d.ts",

--- a/packages/network-express/package.json
+++ b/packages/network-express/package.json
@@ -9,7 +9,8 @@
   "exports": {
     ".": {
       "import": "./dist/es/index.mjs",
-      "require": "./dist/index.js"
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
     }
   },
   "license": "MIT",

--- a/packages/network-msw/package.json
+++ b/packages/network-msw/package.json
@@ -8,7 +8,8 @@
   "exports": {
     ".": {
       "import": "./dist/es/index.mjs",
-      "require": "./dist/index.js"
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
     }
   },
   "types": "dist/index.d.ts",

--- a/packages/network-nock/package.json
+++ b/packages/network-nock/package.json
@@ -8,7 +8,8 @@
   "exports": {
     ".": {
       "import": "./dist/es/index.mjs",
-      "require": "./dist/index.js"
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
     }
   },
   "types": "dist/index.d.ts",

--- a/packages/network-playwright/package.json
+++ b/packages/network-playwright/package.json
@@ -8,7 +8,8 @@
   "exports": {
     ".": {
       "import": "./dist/es/index.mjs",
-      "require": "./dist/index.js"
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
     }
   },
   "types": "dist/index.d.ts",

--- a/packages/network-pretender/package.json
+++ b/packages/network-pretender/package.json
@@ -9,7 +9,8 @@
   "exports": {
     ".": {
       "import": "./dist/es/index.mjs",
-      "require": "./dist/index.js"
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
     }
   },
   "license": "MIT",

--- a/packages/paper/package.json
+++ b/packages/paper/package.json
@@ -8,19 +8,23 @@
   "exports": {
     ".": {
       "import": "./dist/es/index.mjs",
-      "require": "./dist/index.js"
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
     },
     "./document": {
       "import": "./dist/es/document/index.mjs",
-      "require": "./dist/document/index.js"
+      "require": "./dist/document/index.js",
+      "types": "./dist/document/index.d.ts"
     },
     "./operations": {
       "import": "./dist/es/operations/index.mjs",
-      "require": "./dist/operations/index.js"
+      "require": "./dist/operations/index.js",
+      "types": "./dist/operations/index.d.ts"
     },
     "./validations/validators": {
       "import": "./dist/es/validations/validators/index.mjs",
-      "require": "./dist/validations/validators/index.js"
+      "require": "./dist/validations/validators/index.js",
+      "types": "./dist/validations/validators/index.d.ts"
     }
   },
   "types": "dist/index.d.ts",

--- a/packages/sinon/package.json
+++ b/packages/sinon/package.json
@@ -8,7 +8,8 @@
   "exports": {
     ".": {
       "import": "./dist/es/index.mjs",
-      "require": "./dist/index.js"
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
     }
   },
   "types": "dist/index.d.ts",

--- a/scripts/copy-scrubbed-pjson.js
+++ b/scripts/copy-scrubbed-pjson.js
@@ -42,6 +42,10 @@ function cleanPackageJson(pjson) {
     if (map.import) {
       map.import = removeDist(map.import);
     }
+
+    if (map.types) {
+      map.types = removeDist(map.types);
+    }
   });
 
   return copy;


### PR DESCRIPTION
Fixes issue reported in #259

## CHANGELOG

### `graphql-mocks`
```markdown changelog(graphql-mocks)
* (fix) Fixed typescript `types` references in package.json
```

### `graphql-paper`
```markdown changelog(graphql-paper)
* (fix) Fixed typescript `types` references in package.json
```

### `@graphql-mocks/falso`
```markdown changelog(@graphql-mocks/falso)
* (fix) Fixed typescript `types` references in package.json
```

### `@graphql-mocks/mirage`
```markdown changelog(@graphql-mocks/mirage)
* (fix) Fixed typescript `types` references in package.json
```

### `@graphql-mocks/network-cypress`
```markdown changelog(@graphql-mocks/network-cypress)
* (fix) Fixed typescript `types` references in package.json
```

### `@graphql-mocks/network-express`
```markdown changelog(@graphql-mocks/network-express)
* (fix) Fixed typescript `types` references in package.json
```

### `@graphql-mocks/network-msw`
```markdown changelog(@graphql-mocks/network-msw)
* (fix) Fixed typescript `types` references in package.json
```

### `@graphql-mocks/network-nock`
```markdown changelog(@graphql-mocks/network-nock)
* (fix) Fixed typescript `types` references in package.json
```

### `@graphql-mocks/network-playwright`
```markdown changelog(@graphql-mocks/network-playwright)
* (fix) Fixed typescript `types` references in package.json
```

### `@graphql-mocks/network-pretender`
```markdown changelog(@graphql-mocks/network-pretender)
* (fix) Fixed typescript `types` references in package.json
```

### `@graphql-mocks/sinon`
```markdown changelog(@graphql-mocks/sinon)
* (fix) Fixed typescript `types` references in package.json
```
