### PR TITLE
Publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## graphql-mocks
 
+### graphql-mocks@0.11.1
+
+#### Fix package json types references ([#260](https://github.com/graphql-mocks/graphql-mocks/pull/260))
+
+* (fix) Fixed typescript `types` references in package.json
+
 ### graphql-mocks@0.11.0
 
 #### Fix esm imports for node ([#255](https://github.com/graphql-mocks/graphql-mocks/pull/255))
@@ -70,6 +76,12 @@
 * (feature) Add `applyMiddlewares` method to `GraphQLHandler`
 
 ## graphql-paper
+
+### graphql-paper@0.4.1
+
+#### Fix package json types references ([#260](https://github.com/graphql-mocks/graphql-mocks/pull/260))
+
+* (fix) Fixed typescript `types` references in package.json
 
 ### graphql-paper@0.4.0
 
@@ -184,6 +196,12 @@
 
 ## @graphql-mocks/mirage
 
+### @graphql-mocks/mirage@0.9.1
+
+#### Fix package json types references ([#260](https://github.com/graphql-mocks/graphql-mocks/pull/260))
+
+* (fix) Fixed typescript `types` references in package.json
+
 ### @graphql-mocks/mirage@0.9.0
 
 #### Fix esm imports for node ([#255](https://github.com/graphql-mocks/graphql-mocks/pull/255))
@@ -229,6 +247,12 @@
 
 ## @graphql-mocks/falso
 
+### @graphql-mocks/falso@0.7.1
+
+#### Fix package json types references ([#260](https://github.com/graphql-mocks/graphql-mocks/pull/260))
+
+* (fix) Fixed typescript `types` references in package.json
+
 ### @graphql-mocks/falso@0.7.0
 
 #### Fix esm imports for node ([#255](https://github.com/graphql-mocks/graphql-mocks/pull/255))
@@ -263,6 +287,12 @@
 * (feature) Introducing `@graphql-mocks/falso`, replacing @graphql-mocks/faker, as the package to provide fake data across an entire schema. [Falso](https://github.com/ngneat/falso) benefits from being esmodule-first and being actively developed and supported.
 
 ## @graphql-mocks/network-express
+
+### @graphql-mocks/network-express@0.4.1
+
+#### Fix package json types references ([#260](https://github.com/graphql-mocks/graphql-mocks/pull/260))
+
+* (fix) Fixed typescript `types` references in package.json
 
 ### @graphql-mocks/network-express@0.4.0
 
@@ -302,6 +332,12 @@
 
 ## @graphql-mocks/network-msw
 
+### @graphql-mocks/network-msw@0.4.1
+
+#### Fix package json types references ([#260](https://github.com/graphql-mocks/graphql-mocks/pull/260))
+
+* (fix) Fixed typescript `types` references in package.json
+
 ### @graphql-mocks/network-msw@0.4.0
 
 #### Fix esm imports for node ([#255](https://github.com/graphql-mocks/graphql-mocks/pull/255))
@@ -332,6 +368,12 @@
 * (feature) Added package README
 
 ## @graphql-mocks/network-nock
+
+### @graphql-mocks/network-nock@0.6.1
+
+#### Fix package json types references ([#260](https://github.com/graphql-mocks/graphql-mocks/pull/260))
+
+* (fix) Fixed typescript `types` references in package.json
 
 ### @graphql-mocks/network-nock@0.6.0
 
@@ -368,6 +410,12 @@
 
 ## @graphql-mocks/network-pretender
 
+### @graphql-mocks/network-pretender@0.4.1
+
+#### Fix package json types references ([#260](https://github.com/graphql-mocks/graphql-mocks/pull/260))
+
+* (fix) Fixed typescript `types` references in package.json
+
 ### @graphql-mocks/network-pretender@0.4.0
 
 #### Fix esm imports for node ([#255](https://github.com/graphql-mocks/graphql-mocks/pull/255))
@@ -401,6 +449,12 @@
 * (feature) Introducing `@graphql-mocks/network-pretender`, a new browser network handler using pretender.js
 
 ## @graphql-mocks/sinon
+
+### @graphql-mocks/sinon@0.5.1
+
+#### Fix package json types references ([#260](https://github.com/graphql-mocks/graphql-mocks/pull/260))
+
+* (fix) Fixed typescript `types` references in package.json
 
 ### @graphql-mocks/sinon@0.5.0
 
@@ -437,6 +491,12 @@
 
 ## @graphql-mocks/network-cypress
 
+### @graphql-mocks/network-cypress@0.4.1
+
+#### Fix package json types references ([#260](https://github.com/graphql-mocks/graphql-mocks/pull/260))
+
+* (fix) Fixed typescript `types` references in package.json
+
 ### @graphql-mocks/network-cypress@0.4.0
 
 #### Fix esm imports for node ([#255](https://github.com/graphql-mocks/graphql-mocks/pull/255))
@@ -470,6 +530,12 @@
 * (feature) Introducing `@graphql-mocks/network-cypress`, a new network handler for cypress
 
 ## @graphql-mocks/network-playwright
+
+### @graphql-mocks/network-playwright@0.2.1
+
+#### Fix package json types references ([#260](https://github.com/graphql-mocks/graphql-mocks/pull/260))
+
+* (fix) Fixed typescript `types` references in package.json
 
 ### @graphql-mocks/network-playwright@0.2.0
 

--- a/packages/browser-acceptance-tests/package.json
+++ b/packages/browser-acceptance-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browser-acceptance-tests",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "main": "index.js",
   "license": "MIT",
   "private": true,
@@ -13,11 +13,11 @@
     "serve": "http-server build -p 3232"
   },
   "dependencies": {
-    "@graphql-mocks/network-msw": "^0.4.0",
-    "@graphql-mocks/network-pretender": "^0.4.0",
+    "@graphql-mocks/network-msw": "^0.4.1",
+    "@graphql-mocks/network-pretender": "^0.4.1",
     "connect": "^3.7.0",
     "execa": "^9.3.0",
-    "graphql-mocks": "^0.11.0",
+    "graphql-mocks": "^0.11.1",
     "http-server": "^14.1.1",
     "msw": "^2.3.1",
     "pretender": "^3.4.7",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gqlmocks",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "author": "Chad Carbert @chadian",
   "bin": {
     "gqlmocks": "./bin/run"
@@ -12,8 +12,8 @@
     "@babel/plugin-proposal-class-properties": "^7.18.6",
     "@babel/plugin-transform-typescript": "^7.16.8",
     "@babel/register": "^7.17.0",
-    "@graphql-mocks/falso": "^0.7.0",
-    "@graphql-mocks/network-express": "^0.4.0",
+    "@graphql-mocks/falso": "^0.7.1",
+    "@graphql-mocks/network-express": "^0.4.1",
     "@ngneat/falso": "^5.3.0",
     "@oclif/core": "^1",
     "@oclif/plugin-help": "^5",
@@ -29,7 +29,7 @@
     "graphiql-middleware": "^0.0.4",
     "graphql": "^16.2.0",
     "graphql-import-node": "^0.0.4",
-    "graphql-mocks": "^0.11.0",
+    "graphql-mocks": "^0.11.1",
     "handlebars": "^4.7.7",
     "pkg-dir": "^5",
     "ts-node": "^10.5.0",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphql-mocks/docs",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "private": true,
   "scripts": {
     "clean": "docusaurus clear",
@@ -16,12 +16,12 @@
   "dependencies": {
     "@docusaurus/core": "^3.0.0",
     "@docusaurus/preset-classic": "^3.0.0",
-    "@graphql-mocks/mirage": "^0.9.0",
+    "@graphql-mocks/mirage": "^0.9.1",
     "@mdx-js/react": "^3.0.0",
     "classnames": "^2.2.6",
     "graphiql": "1.5.17",
-    "graphql-mocks": "^0.11.0",
-    "graphql-paper": "^0.4.0",
+    "graphql-mocks": "^0.11.1",
+    "graphql-paper": "^0.4.1",
     "graphql-tools": "^6.0.11",
     "prism-react-renderer": "^2.1.0",
     "react": "^18.2.0",

--- a/packages/falso/package.json
+++ b/packages/falso/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphql-mocks/falso",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "author": "Chad Carbert",
   "description": "Fake GraphQL queries with graphql-mocks and Falso",
   "main": "dist/index.js",
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@ngneat/falso": "^7.2.0",
     "@types/sinon": "^17.0.3",
-    "graphql-mocks": "^0.11.0",
+    "graphql-mocks": "^0.11.1",
     "sinon": "^18.0.0"
   },
   "peerDependencies": {

--- a/packages/graphql-mocks/package.json
+++ b/packages/graphql-mocks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-mocks",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "author": "Chad Carbert",
   "description": "Tools for setting up graphql test resolvers",
   "main": "dist/index.js",

--- a/packages/mirage/package.json
+++ b/packages/mirage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphql-mocks/mirage",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "author": "Chad Carbert",
   "description": "Mock graphql using graphql-mocks and miragejs",
   "main": "dist/index.js",
@@ -47,7 +47,7 @@
   "devDependencies": {
     "@types/ramda": "^0.30.0",
     "@types/sinon": "^17.0.3",
-    "graphql-mocks": "^0.11.0",
+    "graphql-mocks": "^0.11.1",
     "miragejs": "^0.1.40",
     "sinon": "^18.0.0"
   },

--- a/packages/network-cypress/package.json
+++ b/packages/network-cypress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphql-mocks/network-cypress",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "author": "Mohammad Ataei",
   "description": "Mock using graphql-mocks with cypress",
   "main": "dist/index.js",
@@ -46,7 +46,7 @@
   "devDependencies": {
     "axios": "^1.7.2",
     "cypress": "^13.13.0",
-    "graphql-mocks": "^0.11.0",
+    "graphql-mocks": "^0.11.1",
     "vite": "^5.3.2"
   },
   "peerDependencies": {

--- a/packages/network-express/package.json
+++ b/packages/network-express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphql-mocks/network-express",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "author": "Chad Carbert",
   "description": "Mock using graphql-mocks with Express",
   "main": "dist/index.js",
@@ -46,7 +46,7 @@
     "@types/express": "^4.17.21",
     "@types/node-fetch": "^2.6.11",
     "express": "^4.19.2",
-    "graphql-mocks": "^0.11.0",
+    "graphql-mocks": "^0.11.1",
     "node-fetch": "^2.6.1"
   },
   "peerDependencies": {

--- a/packages/network-msw/package.json
+++ b/packages/network-msw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphql-mocks/network-msw",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "author": "Chad Carbert",
   "description": "Mock using graphql-mocks with msw (mock service worker)",
   "main": "dist/index.js",
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "execa": "^9.3.0",
-    "graphql-mocks": "^0.11.0",
+    "graphql-mocks": "^0.11.1",
     "msw": "^2.3.1",
     "puppeteer": "^22.12.1"
   },

--- a/packages/network-nock/package.json
+++ b/packages/network-nock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphql-mocks/network-nock",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "author": "Chad Carbert",
   "description": "Mock using graphql-mocks with Nock",
   "main": "dist/index.js",
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@types/nock": "^11.1.0",
     "@types/node-fetch": "^2.6.11",
-    "graphql-mocks": "^0.11.0",
+    "graphql-mocks": "^0.11.1",
     "nock": "^13.5.4",
     "node-fetch": "^2.6.1"
   },

--- a/packages/network-playwright/package.json
+++ b/packages/network-playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphql-mocks/network-playwright",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "author": "Roland Németh",
   "description": "Mock using graphql-mocks with Playwright",
   "main": "dist/index.js",
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.45.0",
-    "graphql-mocks": "^0.11.0",
+    "graphql-mocks": "^0.11.1",
     "serve": "^14.2.3"
   },
   "peerDependencies": {

--- a/packages/network-pretender/package.json
+++ b/packages/network-pretender/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphql-mocks/network-pretender",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "author": "Chad Carbert",
   "description": "Mock using graphql-mocks with pretender.js",
   "main": "dist/index.js",

--- a/packages/paper/package.json
+++ b/packages/paper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-paper",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "author": "Chad Carbert",
   "description": "A flexible in-memory store based on a GraphQL Schema",
   "main": "dist/index.js",
@@ -68,6 +68,6 @@
   },
   "devDependencies": {
     "@types/ramda": "^0.30.0",
-    "graphql-mocks": "^0.11.0"
+    "graphql-mocks": "^0.11.1"
   }
 }

--- a/packages/sinon/package.json
+++ b/packages/sinon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphql-mocks/sinon",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "author": "Chad Carbert",
   "description": "Mock using graphql-mocks with sinon spy",
   "main": "dist/index.js",
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@types/sinon": "^17.0.3",
-    "graphql-mocks": "^0.11.0",
+    "graphql-mocks": "^0.11.1",
     "sinon": "^18.0.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
 - gqlmocks@0.5.1
 - @graphql-mocks/falso@0.7.1
 - graphql-mocks@0.11.1
 - @graphql-mocks/mirage@0.9.1
 - @graphql-mocks/network-cypress@0.4.1
 - @graphql-mocks/network-express@0.4.1
 - @graphql-mocks/network-msw@0.4.1
 - @graphql-mocks/network-nock@0.6.1
 - @graphql-mocks/network-playwright@0.2.1
 - @graphql-mocks/network-pretender@0.4.1
 - graphql-paper@0.4.1
 - @graphql-mocks/sinon@0.5.1