### PR TITLE
Improve managed context of `pack` property

### DIFF
--- a/packages/graphql-mocks/src/graphql/utils/build-context.ts
+++ b/packages/graphql-mocks/src/graphql/utils/build-context.ts
@@ -11,9 +11,16 @@ export function buildContext({
   queryContext?: GraphQLArgs['contextValue'];
   packOptions: PackOptions;
 }): ResolverContext {
-  return {
+  const context = {
     ...(initialContext as Record<string, unknown>),
     ...(queryContext as Record<string, unknown>),
-    pack: packOptions,
   };
+
+  Object.defineProperty(context, 'pack', {
+    value: Object.freeze({ ...packOptions }),
+    configurable: false,
+    writable: false,
+  });
+
+  return context;
 }

--- a/packages/graphql-mocks/src/pack/pack.ts
+++ b/packages/graphql-mocks/src/pack/pack.ts
@@ -1,6 +1,4 @@
 import { clone } from 'ramda';
-import { embed } from '../resolver-map/embed';
-import { embedPackOptionsWrapper } from './utils';
 import { PackOptions, Packer, PackState } from './types';
 import { defaultPackOptions, normalizePackOptions } from './utils/normalize-pack-options';
 
@@ -9,7 +7,7 @@ export const pack: Packer = async function pack(
   middlewares = [],
   packOptions = defaultPackOptions,
 ) {
-  middlewares = [...middlewares, embed({ wrappers: [embedPackOptionsWrapper] })];
+  middlewares = [...middlewares];
 
   // make an initial copy
   let wrappedMap = clone(initialResolversMap);

--- a/packages/graphql-mocks/src/resolver-map/layer.ts
+++ b/packages/graphql-mocks/src/resolver-map/layer.ts
@@ -9,6 +9,7 @@ import { getResolver } from './get-resolver';
 import { setResolver } from './set-resolver';
 import { applyWrappers } from '../resolver';
 import { Packed } from '../pack/types';
+import { embedPackOptionsWrapper } from '../pack/utils';
 
 type LayerOptions = ReplaceableResolverOption & WrappableOption;
 
@@ -37,7 +38,11 @@ export function layer(partials: ResolverMap[], options?: LayerOptions): Resolver
       let resolver = getResolver(layeredResolverMap, reference);
 
       if (resolver && options?.wrappers?.length) {
-        resolver = await applyWrappers(resolver, options.wrappers, {
+        // if there is at least one wrapper, the embedPackOptionsWrapper should also
+        // be included in order to better manage the context and ensure that the `pack`
+        // property is included
+        const wrappers = [embedPackOptionsWrapper, ...(options?.wrappers ?? [])];
+        resolver = await applyWrappers(resolver, wrappers, {
           schema: graphqlSchema,
           resolverMap,
           packOptions,

--- a/packages/graphql-mocks/test/mocks.ts
+++ b/packages/graphql-mocks/test/mocks.ts
@@ -1,5 +1,6 @@
 import { buildSchema, GraphQLObjectType, GraphQLInterfaceType } from 'graphql';
 import { PackOptions } from '../src/pack/types';
+import { createWrapper, WrapperFor } from '../src/resolver';
 
 export const generatePackOptions: (
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -35,3 +36,16 @@ export const userObjectType = schema.getType('User') as GraphQLObjectType;
 export const nameableInterfaceType = schema.getType('Nameable') as GraphQLInterfaceType;
 export const userObjectFields = (userObjectType as GraphQLObjectType).getFields();
 export const userObjectNameField = userObjectFields['name'];
+
+// Useful in wrapper tests where it's necessary to ensure that context is managed and
+// that `pack` property is always included in context
+export const wrapperThatResetsContext = createWrapper(
+  'wrapper-that-resets-context',
+  WrapperFor.FIELD,
+  function (resolver) {
+    return (a, b, _context, d) => {
+      // ignore the context coming in and call resolver with an empty context object
+      return resolver(a, b, {}, d);
+    };
+  },
+);

--- a/packages/graphql-mocks/test/unit/graphql/handler.test.ts
+++ b/packages/graphql-mocks/test/unit/graphql/handler.test.ts
@@ -267,7 +267,6 @@ Syntax Error: Unexpected Name "NOT"`);
       resolverMap,
       initialContext: { fromInitialContext: true },
       dependencies: { graphqlSchema: schemaString },
-      middlewares: [embed({ wrappers: [spyWrapper] })],
     });
 
     await handler.query(`{ hello }`, {}, { fromQueryContext: true });

--- a/packages/graphql-mocks/test/unit/graphql/handler.test.ts
+++ b/packages/graphql-mocks/test/unit/graphql/handler.test.ts
@@ -267,6 +267,7 @@ Syntax Error: Unexpected Name "NOT"`);
       resolverMap,
       initialContext: { fromInitialContext: true },
       dependencies: { graphqlSchema: schemaString },
+      middlewares: [embed({ wrappers: [spyWrapper] })],
     });
 
     await handler.query(`{ hello }`, {}, { fromQueryContext: true });
@@ -276,5 +277,16 @@ Syntax Error: Unexpected Name "NOT"`);
     expect(context.fromQueryContext, 'query context is spread into context').to.exist;
     expect(context.pack, 'is defined in context').to.exist;
     expect(context.pack.dependencies.graphqlSchema, 'graphqlSchema exists in pack dependencies').to.exist;
+
+    const [, , receivedContextinSpyWrapper] = (handler.state.spies.Query.hello as sinon.SinonSpy).firstCall.args;
+    expect(context).to.equal(receivedContextinSpyWrapper);
+
+    // protected `pack` assertions
+    expect(() => {
+      delete context.pack;
+    }, '`pack` is protected, attempting to delete the pack property throws').to.throw;
+    expect(() => {
+      context.pack = 'assignment of pack to something else';
+    }, '`pack` is protected, attempting to delete the pack property throws').to.throw;
   });
 });

--- a/packages/graphql-mocks/test/unit/graphql/handler.test.ts
+++ b/packages/graphql-mocks/test/unit/graphql/handler.test.ts
@@ -278,9 +278,6 @@ Syntax Error: Unexpected Name "NOT"`);
     expect(context.pack, 'is defined in context').to.exist;
     expect(context.pack.dependencies.graphqlSchema, 'graphqlSchema exists in pack dependencies').to.exist;
 
-    const [, , receivedContextinSpyWrapper] = (handler.state.spies.Query.hello as sinon.SinonSpy).firstCall.args;
-    expect(context).to.equal(receivedContextinSpyWrapper);
-
     // protected `pack` assertions
     expect(() => {
       delete context.pack;

--- a/packages/graphql-mocks/test/unit/pack/pack.test.ts
+++ b/packages/graphql-mocks/test/unit/pack/pack.test.ts
@@ -1,7 +1,6 @@
-import { buildSchema, GraphQLResolveInfo } from 'graphql';
+import { buildSchema } from 'graphql';
 import { expect } from 'chai';
 import { ResolverMapMiddleware, ResolverMap } from '../../../src/types';
-import sinon from 'sinon';
 import { pack } from '../../../src/pack';
 
 describe('pack/pack', function () {
@@ -31,35 +30,5 @@ describe('pack/pack', function () {
     expect(wrappedResolvers).to.have.property('Type');
     expect(wrappedResolvers.Type).to.have.property('field');
     expect(wrappedResolvers.OtherType).to.equal(undefined, 'type without a field resolver remains untouched');
-  });
-
-  it('includes the packOptions in resolver context by default', async function () {
-    const graphqlSchema = buildSchema(`type Query {
-      hello: String!
-    }`);
-
-    const queryHelloSpy = sinon.spy();
-    const middlewares: ResolverMapMiddleware[] = [];
-
-    const resolvers = {
-      Query: {
-        hello: queryHelloSpy,
-      },
-    };
-
-    const packOptions = {
-      state: { value: 'hello world' },
-      dependencies: {
-        commonDependency: {},
-        graphqlSchema,
-      },
-    };
-
-    const { resolverMap: wrappedResolvers } = await pack(resolvers, middlewares, packOptions);
-    wrappedResolvers.Query.hello({}, {}, {}, {} as GraphQLResolveInfo);
-
-    expect(queryHelloSpy.called).to.be.true;
-    const [, , context] = queryHelloSpy.firstCall.args;
-    expect(context.pack).to.deep.equal(packOptions);
   });
 });

--- a/packages/graphql-mocks/test/unit/pack/utils.test.ts
+++ b/packages/graphql-mocks/test/unit/pack/utils.test.ts
@@ -1,9 +1,9 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { applyWrappers } from '../../../src/resolver/apply-wrappers';
-import { embedPackOptionsWrapper } from '../../../src/pack/utils';
 import { GraphQLObjectType, GraphQLAbstractType, GraphQLInterfaceType, GraphQLResolveInfo } from 'graphql';
 import { FieldResolver, TypeResolver } from '../../../src/types';
+import { embedPackOptionsWrapper } from '../../../src/pack/utils/embed-pack-options-wrapper';
 
 describe('pack/utils', function () {
   describe('#embedPackOptionsWrapper', function () {

--- a/packages/graphql-mocks/test/unit/resolver-map/layer.test.ts
+++ b/packages/graphql-mocks/test/unit/resolver-map/layer.test.ts
@@ -1,11 +1,10 @@
 import { expect } from 'chai';
 import { buildSchema, GraphQLSchema, GraphQLResolveInfo } from 'graphql';
 import { layer } from '../../../src/resolver-map/layer';
-import { generatePackOptions } from '../../mocks';
+import { generatePackOptions, wrapperThatResetsContext } from '../../mocks';
 import { spy, SinonSpy } from 'sinon';
 import { ResolverInfo, FieldResolver } from '../../../src/types';
 import { PackOptions } from '../../../src/pack/types';
-import { createWrapper, WrapperFor } from '../../../src/resolver';
 
 describe('resolver-map/layer', function () {
   let graphqlSchema: GraphQLSchema;
@@ -140,18 +139,8 @@ describe('resolver-map/layer', function () {
     expect(resolverMap.Nameable.__resolveType).exist;
   });
 
-  context(`pack option`, function () {
+  context(`managed context: pack option`, function () {
     const initialContext = Object.freeze({ initialContext: true });
-    const wrapperThatResetsContext = createWrapper(
-      'wrapper-that-resets-context',
-      WrapperFor.FIELD,
-      function (resolver) {
-        return (a, b, _context, d) => {
-          // ignore the context coming in and call resolver with an empty context object
-          return resolver(a, b, {}, d);
-        };
-      },
-    );
     let queryPersonResolver: FieldResolver & SinonSpy;
     let layerPartial: { Query: { person: typeof queryPersonResolver } };
 


### PR DESCRIPTION
This pull request moves the management of adding of the `pack` property on context _from_ the **`pack` function** _to_ the `embed` and `layer` middlewares.

The main reason to remove the application of `embedPackOptionsWrapper` during the **`pack` function** is because it unnecessarily wraps *every. single. resolver.* with a wrapper that intercepts context and ensures `pack` is included. Wrapping every single resolver at pack-time (usually on first query) is a huge unnecessary slow down with large schemas. This was discovered in #272. 

By moving this "managed context" protection to the `layer` and `embed` middleware implementations (the two ways of applying wrappers with graphql-mocks) it means it is more closely guarding against other wrappers at the place where wrappers are applied. Only when there are wrappers does the defensive `embedPackOptionsWrapper` need to be used.

If there are no wrappers applied there's no chance of context dropping the `pack` option on context, the resolver placed on the resolver map will be called at query-time with the managed context including `pack`. If there is at least one wrapper then the wrapper could set up a new context and forget to include `pack`, because multiple wrappers can be very deep, troubleshooting why the `pack` isn't there could be difficult and end up causing confusion when using something like `extractDependencies` within a handler that depends on the `pack` option existing on context. When there is one wrapper placing `embedPackOptionsWrapper` just before it ensures that any resolver receives a context injected with `pack` regardless of what the wrapper before it did to context, eg: failing to pass it along or setting up a new context object.

Ultimately, moving from resolver wrappers to resolver pipelines (something like #195) would set up a control flow that's easier to manage context and be a better mental model that the "Russian doll" effect that resolver wrappers create.

As an added precaution this pull request also freezes the `pack` property on context and its contents to prevent tampering.

## CHANGELOG
### `graphql-mocks`
```markdown changelog(graphql-mocks)
* (feature) Improve performance of `pack` on first query for `GraphQLHandler` by removing `embedPackOptionsWrapper` and using it only within `embed` and `layer` middlewares when necessary
* (feature) Added safeguards on `pack` property on resolver context
* (feature) Move `embedPackOptionsWrapper` managed context safety to `embed` and `layer` middlewares
```