### PR TITLE
Replace resolver attaching to schema with resolver routers

### DIFF
--- a/packages/graphql-mocks/src/graphql/resolver-router.ts
+++ b/packages/graphql-mocks/src/graphql/resolver-router.ts
@@ -1,0 +1,34 @@
+import { defaultFieldResolver, defaultTypeResolver } from 'graphql';
+import { FieldResolver, ResolverMap, TypeResolver } from '../types';
+
+export function createFieldResolverRouter(resolverMap: ResolverMap): FieldResolver {
+  return (parent, args, context, info) => {
+    const { fieldName, parentType } = info;
+    const resolver = resolverMap[parentType.name]?.[fieldName];
+
+    let result;
+    if (resolver) {
+      result = resolver(parent, args, context, info);
+    } else {
+      result = defaultFieldResolver(parent, args, context, info);
+    }
+
+    if (typeof result === 'function') {
+      result = result(parent, args, context, info);
+    }
+
+    return result;
+  };
+}
+
+export function createTypeResolverRouter(resolverMap: ResolverMap): TypeResolver {
+  return function (value, context, info, abstractType) {
+    const resolver = resolverMap[abstractType.name]?.__resolveType;
+
+    if (resolver) {
+      return resolver(value, context, info, abstractType);
+    }
+
+    return defaultTypeResolver(value, context, info, abstractType);
+  };
+}

--- a/packages/graphql-mocks/test/unit/graphql/handler.test.ts
+++ b/packages/graphql-mocks/test/unit/graphql/handler.test.ts
@@ -115,12 +115,26 @@ Syntax Error: Unexpected Name "NOT"`);
         dependencies: { graphqlSchema: schemaString },
       });
 
-      expect(handler.state?.spies?.Query?.hello).to.not.exist;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((handler as any).packed).to.be.false;
       await handler.query(`{ hello }`);
-      expect(handler.state?.spies?.Query?.hello).to.exist;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((handler as any).packed).to.be.true;
     });
 
-    it('packs middlewares when #pack is called', async function () {});
+    it('packs middlewares when #pack is called', async function () {
+      const handler = new GraphQLHandler({
+        resolverMap,
+        middlewares: [middleware],
+        dependencies: { graphqlSchema: schemaString },
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((handler as any).packed).to.be.false;
+      await handler.pack();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((handler as any).packed).to.be.true;
+    });
 
     it('accepts middlewares via options', function () {
       const handlerWithoutMiddlewares = new GraphQLHandler({

--- a/packages/graphql-mocks/test/unit/graphql/handler.test.ts
+++ b/packages/graphql-mocks/test/unit/graphql/handler.test.ts
@@ -282,7 +282,6 @@ Syntax Error: Unexpected Name "NOT"`);
 
         type World {
           earth: String!
-          mars: String!
         }
      `;
 
@@ -353,6 +352,27 @@ Syntax Error: Unexpected Name "NOT"`);
       `);
 
       expect(result.data!.hello).to.equal('hello there!');
+    });
+
+    it('routes to a nested type when it exists on the resolver map', async function () {
+      const worldEarthValue = 'world.earth resolver called!';
+      spies.worldEarth.returns(worldEarthValue);
+      const result = await handler.query<{ world: { earth: string } }>(
+        `
+        {
+          world {
+            earth
+          }
+        }
+      `,
+        {},
+        {},
+        // quick way to kick off Query.world resolver without having a Query.world
+        // resolver in the resolver map
+        { rootValue: { world: {} } },
+      );
+
+      expect(result.data!.world.earth).to.equal(worldEarthValue);
     });
 
     it('returns `null` if the routed resolver returns `undefined`', async function () {

--- a/packages/graphql-mocks/test/unit/wrapper/latency.test.ts
+++ b/packages/graphql-mocks/test/unit/wrapper/latency.test.ts
@@ -48,7 +48,7 @@ describe('wrapper/latency', function () {
   });
 
   it('delays for a specific amount of milliseconds', async function () {
-    const latency = 1000;
+    const latency = 400;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const wrappedResolver = await latencyWrapper(latency).wrap(resolverSpy, {} as any);
     timer.start();
@@ -60,7 +60,7 @@ describe('wrapper/latency', function () {
   });
 
   it('delays for a range of milliseconds', async function () {
-    const latency: [number, number] = [1000, 1500];
+    const latency: [number, number] = [300, 500];
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const wrappedResolver = await latencyWrapper(latency).wrap(resolverSpy, {} as any);
     timer.start();


### PR DESCRIPTION
This pull request aims to increase performance a bit by skipping attaching every resolver from a resolver map to schema types, and instead have a _resolver router_. The resolver router will lookup a resolver based on the current resolver info and pass along the same arguments it received. There is a separate field and type resolver routers. 

## CHANGELOG
### `graphql-mocks`
```markdown changelog(graphql-mocks)
* (feature) Use routing resolvers instead of attaching resolvers directly to schema types
* (feature) `GraphQLHandler#pack` is now public. Previously this was done internally to "pack together" all the resolver map middlewares, and because it was async it was deferred to the first query. With it being a public method on `GraphQLHandler it can be called earlier so that the first query isn't slowed down
```
