### PR TITLE
Highlight performance improvements

### DIFF
--- a/packages/graphql-mocks/src/highlight/highlight.ts
+++ b/packages/graphql-mocks/src/highlight/highlight.ts
@@ -1,5 +1,4 @@
 import { GraphQLSchema } from 'graphql';
-import { clone } from 'ramda';
 import { include } from './operation/include';
 import { exclude } from './operation/exclude';
 import { filter } from './operation/filter';
@@ -71,7 +70,7 @@ export class Highlight {
     const schema = this.schema;
 
     // all changes are implemented with a fresh copy of data
-    const references = clone(this.references);
+    const references = [...this.references];
 
     let updated = highlighters
       .reduce((references: Reference[], highlighter: Highlighter) => {

--- a/packages/graphql-mocks/src/highlight/utils/convert-highlighter-or-reference-to-highlighter.ts
+++ b/packages/graphql-mocks/src/highlight/utils/convert-highlighter-or-reference-to-highlighter.ts
@@ -7,12 +7,12 @@ import { reference as referenceHighlighter } from '../highlighter/reference';
 export function convertHighlighterOrReferenceToHighlighter(
   highlighterOrReference: Highlighter | Reference,
 ): Highlighter | undefined {
-  if (isTypeReference(highlighterOrReference) || isFieldReference(highlighterOrReference)) {
-    return referenceHighlighter(highlighterOrReference);
-  }
-
   if (isHighlighter(highlighterOrReference)) {
     return highlighterOrReference;
+  }
+
+  if (isTypeReference(highlighterOrReference) || isFieldReference(highlighterOrReference)) {
+    return referenceHighlighter(highlighterOrReference);
   }
 
   return undefined;

--- a/packages/graphql-mocks/src/highlight/utils/reference-set-helpers.ts
+++ b/packages/graphql-mocks/src/highlight/utils/reference-set-helpers.ts
@@ -19,6 +19,10 @@ export function referenceIntersection(groupA: Reference[], groupB: Reference[]) 
 }
 
 export function referenceDifference(groupA: Reference[], groupB: Reference[]) {
+  if (groupA.length === 0 || groupB.length === 0) {
+    return groupA;
+  }
+
   const maskedGroupA = new Set(groupA.map(maskReference));
   const maskedGroupB = new Set(groupB.map(maskReference));
 


### PR DESCRIPTION
## CHANGELOG
More highlight improvements, as a follow up to #274

Performance improvements in this PR:
* `clone` was a silly way of making an array with the same references as an existing array. This was hugely expensive.
* Added early returns where work could be avoided
* Use less array functions to avoid creating new arrays over and over when a single `for` iteration will do

### `graphql-mocks`
```markdown changelog(graphql-mocks)
* (feature) Further performance improvements of highlighting and highlighters
```
