### PR TITLE
Avoid array.push with spread of large array of arguments

### DIFF
--- a/packages/graphql-mocks/src/highlight/highlighter/field.ts
+++ b/packages/graphql-mocks/src/highlight/highlighter/field.ts
@@ -22,7 +22,9 @@ export class FieldHighlighter implements Highlighter {
 
     for (const target of targets) {
       const fr = FieldHighlighter.expandTarget(schema, target);
-      fieldReferences.push(...fr);
+      for (const fieldReference of fr) {
+        fieldReferences.push(fieldReference);
+      }
     }
 
     return fieldReferences;


### PR DESCRIPTION
Ran into a `RangeError: Maximum call stack size exceeded with array.push(...)` locally with some performance testing with a _very_ large schema. Spreading an array as arguments pushes it on to the stack and ends up maxing out the call for `push`.

## CHANGELOG
### `graphql-mocks`
```markdown changelog(graphql-mocks)
* (fix) Fix "RangeError: Maximum call stack size exceeded" by avoiding spreading large list of highlight references
```
