### PR TITLE
Publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -181,6 +181,12 @@
 
 ## gqlmocks
 
+### gqlmocks@0.5.5
+
+#### Fix graphiql when using `gqlmocks  serve` by updating graphiql-middleware ([#295](https://github.com/graphql-mocks/graphql-mocks/pull/295))
+
+* (fix) Fix graphiql in `gqlmocks serve` failing to load due to React 19+ UMD bundle removal
+
 ### gqlmocks@0.5.2
 
 #### Bump dependencies ([#268](https://github.com/graphql-mocks/graphql-mocks/pull/268))

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gqlmocks",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "author": "Chad Carbert @chadian",
   "bin": {
     "gqlmocks": "./bin/run"

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphql-mocks/docs",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "private": true,
   "scripts": {
     "clean": "docusaurus clear",


### PR DESCRIPTION
 - gqlmocks@0.5.5
 - @graphql-mocks/falso@0.7.4
 - graphql-mocks@0.11.4
 - @graphql-mocks/network-cypress@0.4.4
 - @graphql-mocks/network-express@0.4.4
 - @graphql-mocks/network-msw@0.4.4
 - @graphql-mocks/network-nock@0.6.4
 - @graphql-mocks/network-playwright@0.2.4
 - @graphql-mocks/network-pretender@0.4.4
 - graphql-paper@0.5.0
 - @graphql-mocks/sinon@0.5.4