### PR TITLE
Skip deprecated packages in changelog portion of create-release script

### DIFF
--- a/scripts/create-release.js
+++ b/scripts/create-release.js
@@ -8,6 +8,8 @@ const chalk = require('chalk');
 const { writeFileSync, readFileSync } = require('fs');
 const path = require('path');
 
+const deprecatedPackages = ['@graphql-mocks/mirage'];
+
 function pnpmAndLink({ retry } = { retry: true }) {
   console.log(chalk.blue(`running \`pnpm\` and \`pnpm link-packages\``));
   try {
@@ -184,6 +186,8 @@ function attachChangelogs(packages) {
   });
 
   changelogs.forEach(({ package: packageName, entry, pr }) => {
+    if (deprecatedPackages.includes(packageName)) return;
+
     const package = packages.find(({ name }) => name === packageName);
 
     if (!package) {


### PR DESCRIPTION
Ensure that `@graphql-mocks/mirage` is skipped when trying to manage packages in the changelog